### PR TITLE
#MobLockHandler added: Prevent damage to mobs locked behind stages

### DIFF
--- a/src/main/java/net/bananemdnsa/historystages/Config.java
+++ b/src/main/java/net/bananemdnsa/historystages/Config.java
@@ -18,6 +18,9 @@ public class Config {
         public final ForgeConfigSpec.BooleanValue dimUseActionbar;
         public final ForgeConfigSpec.BooleanValue dimShowChat;
         public final ForgeConfigSpec.BooleanValue dimShowStagesInChat;
+        public final ForgeConfigSpec.BooleanValue mobUseActionbar;
+        public final ForgeConfigSpec.BooleanValue mobShowChat;
+        public final ForgeConfigSpec.BooleanValue mobShowStagesInChat;
 
         public Client(ForgeConfigSpec.Builder builder) {
             builder.comment("Visual and UI settings (Individual for each player)").push("visuals");
@@ -52,6 +55,22 @@ public class Config {
 
             dimShowStagesInChat = builder
                     .comment("If dimShowChat is true, should the required stages also be listed? [Default: true]")
+                    .define("showStagesInChat", true);
+
+            builder.pop();
+
+            builder.comment("Settings for mob damage lock feedback").push("mob_lock");
+
+            mobUseActionbar = builder
+                    .comment("Show a 'Mob Protected' message in the actionbar? [Default: true]")
+                    .define("useActionbar", true);
+
+            mobShowChat = builder
+                    .comment("Show the mob lock message in the chat? [Default: false]")
+                    .define("showInChat", false);
+
+            mobShowStagesInChat = builder
+                    .comment("If mobShowChat is true, should the required stages also be listed? [Default: true]")
                     .define("showStagesInChat", true);
 
             builder.pop();

--- a/src/main/java/net/bananemdnsa/historystages/ConfigHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/ConfigHandler.java
@@ -64,6 +64,12 @@ public class ConfigHandler {
         dimensions.add("minecraft:the_end");
         json.add("dimensions", dimensions);
 
+        // Entities Category
+        JsonArray entities = new JsonArray();
+        entities.add("minecraft:zombie");
+        entities.add("minecraft:skeleton");
+        json.add("entities", entities);
+
         try (FileWriter writer = new FileWriter(file)) {
             GSON.toJson(json, writer);
         } catch (IOException e) {

--- a/src/main/java/net/bananemdnsa/historystages/commands/StageCommand.java
+++ b/src/main/java/net/bananemdnsa/historystages/commands/StageCommand.java
@@ -75,6 +75,11 @@ public class StageCommand {
                                         entry.getDimensions().forEach(d -> ctx.getSource().sendSuccess(() -> Component.literal("  §8• §7" + d), false));
                                     }
 
+                                    if (!entry.getEntities().isEmpty()) {
+                                        ctx.getSource().sendSuccess(() -> Component.literal("§c▶ Entities:"), false);
+                                        entry.getEntities().forEach(e -> ctx.getSource().sendSuccess(() -> Component.literal("  §8• §7" + e), false));
+                                    }
+
                                     return 1;
                                 })))
 

--- a/src/main/java/net/bananemdnsa/historystages/data/StageEntry.java
+++ b/src/main/java/net/bananemdnsa/historystages/data/StageEntry.java
@@ -12,6 +12,7 @@ public class StageEntry {
     private List<String> tags;
     private List<String> mods;
     private List<String> dimensions; // NEU
+    private List<String> entities;
 
     public String getDisplayName() {
         return displayName != null ? displayName : "Unknown Stage";
@@ -24,5 +25,9 @@ public class StageEntry {
     // NEU: Getter für Dimensionen
     public List<String> getDimensions() {
         return dimensions != null ? dimensions : new ArrayList<>();
+    }
+
+    public List<String> getEntities() {
+        return entities != null ? entities : new ArrayList<>();
     }
 }

--- a/src/main/java/net/bananemdnsa/historystages/data/StageManager.java
+++ b/src/main/java/net/bananemdnsa/historystages/data/StageManager.java
@@ -77,6 +77,15 @@ public class StageManager {
             return false;
         });
 
+        // Entities prüfen
+        entry.getEntities().removeIf(entityId -> {
+            if (!ResourceLocation.isValidResourceLocation(entityId)) {
+                LOADING_ERRORS.add("§7[Debug] §fEntity §e" + entityId + " §finvalid (Stage: §b" + stageId + "§f). Skipping.");
+                return true;
+            }
+            return false;
+        });
+
         STAGES.put(stageId, entry);
         System.out.println("[HistoryStages] Stage geladen: " + stageId);
     }
@@ -109,6 +118,16 @@ public class StageManager {
                         if (item.builtInRegistryHolder().is(tagKey)) return stageName;
                     }
                 }
+            }
+        }
+        return null;
+    }
+
+    public static String getStageForEntity(String entityId) {
+        for (var entry : STAGES.entrySet()) {
+            StageEntry data = entry.getValue();
+            if (data.getEntities() != null && data.getEntities().contains(entityId)) {
+                return entry.getKey();
             }
         }
         return null;

--- a/src/main/java/net/bananemdnsa/historystages/events/MobLockHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/events/MobLockHandler.java
@@ -1,0 +1,71 @@
+package net.bananemdnsa.historystages.events;
+
+import net.bananemdnsa.historystages.Config;
+import net.bananemdnsa.historystages.HistoryStages;
+import net.bananemdnsa.historystages.data.StageEntry;
+import net.bananemdnsa.historystages.data.StageManager;
+import net.bananemdnsa.historystages.util.StageData;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraftforge.event.entity.living.LivingAttackEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Mod.EventBusSubscriber(modid = HistoryStages.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class MobLockHandler {
+
+    private static final Map<UUID, Long> MESSAGE_COOLDOWNS = new HashMap<>();
+    private static final long COOLDOWN_MS = 2000;
+
+    @SubscribeEvent
+    public static void onMobAttacked(LivingAttackEvent event) {
+        if (event.getEntity().level().isClientSide()) return;
+
+        if (!(event.getSource().getEntity() instanceof ServerPlayer player)) return;
+
+        ResourceLocation entityType = ForgeRegistries.ENTITY_TYPES.getKey(event.getEntity().getType());
+        if (entityType == null) return;
+
+        String entityId = entityType.toString();
+        String requiredStageId = StageManager.getStageForEntity(entityId);
+
+        if (requiredStageId != null && !StageData.SERVER_CACHE.contains(requiredStageId)) {
+            event.setCanceled(true);
+
+            // Cooldown um Nachrichtenspam zu vermeiden
+            long now = System.currentTimeMillis();
+            Long lastMessage = MESSAGE_COOLDOWNS.get(player.getUUID());
+            if (lastMessage != null && (now - lastMessage) < COOLDOWN_MS) return;
+            MESSAGE_COOLDOWNS.put(player.getUUID(), now);
+
+            StageEntry stageEntry = StageManager.getStages().get(requiredStageId);
+            String stageDisplayName = (stageEntry != null) ? stageEntry.getDisplayName() : requiredStageId;
+
+            if (Config.CLIENT.mobShowChat.get()) {
+                MutableComponent chatMsg = Component.translatable("message.historystages.mob_locked");
+
+                if (Config.CLIENT.mobShowStagesInChat.get()) {
+                    chatMsg.append(Component.translatable("message.historystages.mob_locked_stage", stageDisplayName));
+                }
+
+                player.sendSystemMessage(chatMsg);
+            }
+
+            if (Config.CLIENT.mobUseActionbar.get()) {
+                player.displayClientMessage(
+                        Component.translatable("message.historystages.mob_unknown")
+                                .withStyle(ChatFormatting.DARK_RED, ChatFormatting.ITALIC),
+                        true
+                );
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/historystages/lang/en_us.json
+++ b/src/main/resources/assets/historystages/lang/en_us.json
@@ -10,5 +10,8 @@
   "tooltip.historystages.research_scroll.info2": "to unlock new technologies.",
   "message.historystages.dimension_locked": "§cYou haven't reached the required era to enter this dimension!",
   "message.historystages.dimension_locked_stage": " §8(Required: §e%s§8)",
-  "message.historystages.dimension_unknown": "??? This dimension is still unknown to you ???"
+  "message.historystages.dimension_unknown": "??? This dimension is still unknown to you ???",
+  "message.historystages.mob_locked": "§cYou don't have the knowledge to harm this creature!",
+  "message.historystages.mob_locked_stage": " §8(Required: §e%s§8)",
+  "message.historystages.mob_unknown": "??? This creature is still unknown to you ???"
 }


### PR DESCRIPTION
Adds a new "entities" field to stage JSON configs. When a stage is locked, players cannot damage mobs listed in that stage. Includes configurable actionbar/chat feedback (like dimension lock) with spam cooldown.