### PR TITLE
Toast notification for stage unlocks

### DIFF
--- a/src/main/java/net/bananemdnsa/historystages/Config.java
+++ b/src/main/java/net/bananemdnsa/historystages/Config.java
@@ -92,6 +92,7 @@ public class Config {
         public final ForgeConfigSpec.ConfigValue<String> unlockMessageFormat;
         public final ForgeConfigSpec.BooleanValue useActionbar;
         public final ForgeConfigSpec.BooleanValue useSounds;
+        public final ForgeConfigSpec.BooleanValue useToasts;
 
         // Forschungsstation
         public final ForgeConfigSpec.IntValue researchTimeInSeconds;
@@ -131,6 +132,10 @@ public class Config {
             useSounds = builder
                     .comment("Play notification sounds for everyone? [Default: true]")
                     .define("useSounds", true);
+
+            useToasts = builder
+                    .comment("Show an advancement-style toast popup when a stage is unlocked? [Default: true]")
+                    .define("useToasts", true);
 
             builder.pop(); // Schließt "notifications"
 

--- a/src/main/java/net/bananemdnsa/historystages/block/entity/ResearchPedestalBlockEntity.java
+++ b/src/main/java/net/bananemdnsa/historystages/block/entity/ResearchPedestalBlockEntity.java
@@ -194,6 +194,11 @@ public class ResearchPedestalBlockEntity extends BlockEntity implements MenuProv
                         player.playNotifySound(SoundEvents.UI_TOAST_CHALLENGE_COMPLETE, SoundSource.MASTER, 0.75F, 1.0F);
                     }
                 });
+
+                // Toast notification
+                if (Config.COMMON.useToasts.get()) {
+                    PacketHandler.sendToastToAll(new net.bananemdnsa.historystages.network.StageUnlockedToastPacket(stagename));
+                }
             }
         }
 

--- a/src/main/java/net/bananemdnsa/historystages/client/ClientToastHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/client/ClientToastHandler.java
@@ -1,0 +1,10 @@
+package net.bananemdnsa.historystages.client;
+
+import net.minecraft.client.Minecraft;
+
+public class ClientToastHandler {
+    public static void showToast(String stageName) {
+        Minecraft mc = Minecraft.getInstance();
+        mc.execute(() -> mc.getToasts().addToast(new StageUnlockedToast(stageName)));
+    }
+}

--- a/src/main/java/net/bananemdnsa/historystages/client/StageUnlockedToast.java
+++ b/src/main/java/net/bananemdnsa/historystages/client/StageUnlockedToast.java
@@ -1,0 +1,45 @@
+package net.bananemdnsa.historystages.client;
+
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.toasts.Toast;
+import net.minecraft.client.gui.components.toasts.ToastComponent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+
+public class StageUnlockedToast implements Toast {
+
+    private static final ResourceLocation TEXTURE = new ResourceLocation("textures/gui/toasts.png");
+    private static final ResourceLocation ICON = new ResourceLocation("historystages", "textures/item/research_scroll.png");
+
+    private final Component title;
+    private final Component stageName;
+    private long firstRender = -1;
+    private static final long DISPLAY_TIME = 5000L;
+
+    public StageUnlockedToast(String stageName) {
+        this.title = Component.translatable("toast.historystages.stage_unlocked");
+        this.stageName = Component.literal(stageName);
+    }
+
+    @Override
+    public Visibility render(GuiGraphics guiGraphics, ToastComponent toastComponent, long timeSinceLastVisible) {
+        if (this.firstRender == -1) {
+            this.firstRender = timeSinceLastVisible;
+        }
+
+        // Draw the vanilla toast background (challenge frame at UV 0,32 for purple tint)
+        guiGraphics.blit(TEXTURE, 0, 0, 0, 32, this.width(), this.height());
+
+        // Draw title text (line 1)
+        guiGraphics.drawString(toastComponent.getMinecraft().font, this.title, 30, 7, 0xFF800080, false);
+
+        // Draw stage name (line 2)
+        guiGraphics.drawString(toastComponent.getMinecraft().font, this.stageName, 30, 18, 0xFFFFFFFF, false);
+
+        // Draw the research scroll icon (16x16 at position 8,8)
+        guiGraphics.blit(ICON, 8, 8, 0, 0, 16, 16, 16, 16);
+
+        return (timeSinceLastVisible - this.firstRender) >= DISPLAY_TIME
+                ? Visibility.HIDE : Visibility.SHOW;
+    }
+}

--- a/src/main/java/net/bananemdnsa/historystages/commands/StageCommand.java
+++ b/src/main/java/net/bananemdnsa/historystages/commands/StageCommand.java
@@ -156,7 +156,7 @@ public class StageCommand {
     }
 
     private static void broadcastEffect(CommandSourceStack source, String stageID, boolean isUnlock) {
-        if (!Config.COMMON.broadcastChat.get() && !Config.COMMON.useActionbar.get() && !Config.COMMON.useSounds.get()) return;
+        if (!Config.COMMON.broadcastChat.get() && !Config.COMMON.useActionbar.get() && !Config.COMMON.useSounds.get() && !Config.COMMON.useToasts.get()) return;
 
         String name = stageID.equals("*") ? "All Progress" : (StageManager.getStages().containsKey(stageID) ? StageManager.getStages().get(stageID).getDisplayName() : stageID);
 
@@ -195,6 +195,11 @@ public class StageCommand {
                 player.playNotifySound(isUnlock ? SoundEvents.UI_TOAST_CHALLENGE_COMPLETE : SoundEvents.BEACON_DEACTIVATE, SoundSource.MASTER, 0.75F, 1.0F);
             }
         });
+
+        // Toast notification
+        if (isUnlock && Config.COMMON.useToasts.get()) {
+            PacketHandler.sendToastToAll(new net.bananemdnsa.historystages.network.StageUnlockedToastPacket(name));
+        }
     }
 
     private static int syncAndReload(CommandSourceStack source, StageData data, String msg) {

--- a/src/main/java/net/bananemdnsa/historystages/network/PacketHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/PacketHandler.java
@@ -19,6 +19,7 @@ public class PacketHandler {
     public static void register() {
         int id = 0;
         INSTANCE.registerMessage(id++, SyncStagesPacket.class, SyncStagesPacket::encode, SyncStagesPacket::decode, SyncStagesPacket::handle);
+        INSTANCE.registerMessage(id++, StageUnlockedToastPacket.class, StageUnlockedToastPacket::encode, StageUnlockedToastPacket::decode, StageUnlockedToastPacket::handle);
     }
 
     // Hilfsmethode, um das Paket an alle Spieler zu senden
@@ -29,5 +30,10 @@ public class PacketHandler {
     // Hilfsmethode, um das Paket an einen bestimmten Spieler zu senden (z.B. beim Login)
     public static void sendToPlayer(SyncStagesPacket packet, ServerPlayer player) {
         INSTANCE.send(PacketDistributor.PLAYER.with(() -> player), packet);
+    }
+
+    // Toast-Benachrichtigung an alle Spieler senden
+    public static void sendToastToAll(StageUnlockedToastPacket packet) {
+        INSTANCE.send(PacketDistributor.ALL.noArg(), packet);
     }
 }

--- a/src/main/java/net/bananemdnsa/historystages/network/StageUnlockedToastPacket.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/StageUnlockedToastPacket.java
@@ -1,0 +1,31 @@
+package net.bananemdnsa.historystages.network;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.function.Supplier;
+
+public class StageUnlockedToastPacket {
+    private final String stageName;
+
+    public StageUnlockedToastPacket(String stageName) {
+        this.stageName = stageName;
+    }
+
+    public static void encode(StageUnlockedToastPacket msg, FriendlyByteBuf buffer) {
+        buffer.writeUtf(msg.stageName);
+    }
+
+    public static StageUnlockedToastPacket decode(FriendlyByteBuf buffer) {
+        return new StageUnlockedToastPacket(buffer.readUtf());
+    }
+
+    public static void handle(StageUnlockedToastPacket msg, Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            if (net.minecraftforge.fml.loading.FMLEnvironment.dist == net.minecraftforge.api.distmarker.Dist.CLIENT) {
+                net.bananemdnsa.historystages.client.ClientToastHandler.showToast(msg.stageName);
+            }
+        });
+        ctx.get().setPacketHandled(true);
+    }
+}

--- a/src/main/resources/assets/historystages/lang/en_us.json
+++ b/src/main/resources/assets/historystages/lang/en_us.json
@@ -12,5 +12,6 @@
   "message.historystages.locked_stage": " §8(Required: §e%s§8)",
   "message.historystages.dimension_unknown": "??? This dimension is still unknown to you ???",
   "message.historystages.mob_locked": "§cYou don't have the knowledge to harm this creature!",
-  "message.historystages.mob_unknown": "??? This creature is still unknown to you ???"
+  "message.historystages.mob_unknown": "??? This creature is still unknown to you ???",
+  "toast.historystages.stage_unlocked": "Stage Unlocked!"
 }


### PR DESCRIPTION
## Summary
- Added advancement-style toast popup when a stage is unlocked (scroll icon + stage name)
- New network packet `StageUnlockedToastPacket` for server-to-client toast triggers
- Custom `StageUnlockedToast` renderer using vanilla toast background
- New config toggle `useToasts` (default: true) in notifications section
- Works with both `/history unlock` command and Research Pedestal

## Test plan
- [x] Run `/history unlock <stage>` and verify toast appears with scroll icon and stage name
- [x] Complete research on a Research Pedestal and verify toast appears
- [x] Set `useToasts = false` in config and verify no toast is shown
- [x] Test on dedicated server to verify no client class loading issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)