### PR TITLE
Fix dedicated server config crash

### DIFF
--- a/src/main/java/net/bananemdnsa/historystages/Config.java
+++ b/src/main/java/net/bananemdnsa/historystages/Config.java
@@ -19,13 +19,7 @@ public class Config {
         public final ForgeConfigSpec.BooleanValue jadeStageName;
         public final ForgeConfigSpec.BooleanValue jadeShowAllUntilComplete;
 
-        public final ForgeConfigSpec.BooleanValue dimUseActionbar;
-        public final ForgeConfigSpec.BooleanValue dimShowChat;
-        public final ForgeConfigSpec.BooleanValue dimShowStagesInChat;
         public final ForgeConfigSpec.BooleanValue showLockIcons;
-        public final ForgeConfigSpec.BooleanValue mobUseActionbar;
-        public final ForgeConfigSpec.BooleanValue mobShowChat;
-        public final ForgeConfigSpec.BooleanValue mobShowStagesInChat;
 
         // Individual Stages
         public final ForgeConfigSpec.BooleanValue showSilverLockIcons;
@@ -73,37 +67,6 @@ public class Config {
 
             builder.pop();
 
-            builder.comment("Settings for dimension access feedback").push("dimension_lock");
-
-            dimUseActionbar = builder
-                    .comment("Show a simple 'Dimension Locked' message in the actionbar? [Default: true]?")
-                    .define("useActionbar", true);
-
-            dimShowChat = builder
-                    .comment("Show the dimension lock message in the chat? [Default: false]")
-                    .define("showInChat", false);
-
-            dimShowStagesInChat = builder
-                    .comment("If dimShowChat is true, should the required stages also be listed? [Default: true]")
-                    .define("showStagesInChat", true);
-
-            builder.pop();
-
-            builder.comment("Settings for mob damage lock feedback").push("mob_lock");
-
-            mobUseActionbar = builder
-                    .comment("Show a 'Mob Protected' message in the actionbar? [Default: true]")
-                    .define("useActionbar", true);
-
-            mobShowChat = builder
-                    .comment("Show the mob lock message in the chat? [Default: false]")
-                    .define("showInChat", false);
-
-            mobShowStagesInChat = builder
-                    .comment("If mobShowChat is true, should the required stages also be listed? [Default: true]")
-                    .define("showStagesInChat", true);
-            builder.pop();
-
             builder.comment("Individual Stage Visual Settings").push("individual_stages");
 
             showSilverLockIcons = builder
@@ -147,6 +110,12 @@ public class Config {
         public final ForgeConfigSpec.BooleanValue lockBlockInteraction;
         public final ForgeConfigSpec.BooleanValue lockContainerInteraction;
         public final ForgeConfigSpec.BooleanValue lockEnchanting;
+        public final ForgeConfigSpec.BooleanValue dimUseActionbar;
+        public final ForgeConfigSpec.BooleanValue dimShowChat;
+        public final ForgeConfigSpec.BooleanValue dimShowStagesInChat;
+        public final ForgeConfigSpec.BooleanValue mobUseActionbar;
+        public final ForgeConfigSpec.BooleanValue mobShowChat;
+        public final ForgeConfigSpec.BooleanValue mobShowStagesInChat;
 
         // Zentrale Benachrichtigungen (Chat, Actionbar, Sounds, Texte)
         public final ForgeConfigSpec.BooleanValue broadcastChat;
@@ -247,6 +216,37 @@ public class Config {
                     .define("lockEnchanting", true);
 
             builder.pop(); // gameplay
+
+            builder.comment("Settings for dimension access feedback").push("dimension_lock");
+
+            dimUseActionbar = builder
+                    .comment("Show a simple 'Dimension Locked' message in the actionbar? [Default: true]?")
+                    .define("useActionbar", true);
+
+            dimShowChat = builder
+                    .comment("Show the dimension lock message in the chat? [Default: false]")
+                    .define("showInChat", false);
+
+            dimShowStagesInChat = builder
+                    .comment("If dimShowChat is true, should the required stages also be listed? [Default: true]")
+                    .define("showStagesInChat", true);
+
+            builder.pop();
+
+            builder.comment("Settings for mob damage lock feedback").push("mob_lock");
+
+            mobUseActionbar = builder
+                    .comment("Show a 'Mob Protected' message in the actionbar? [Default: true]")
+                    .define("useActionbar", true);
+
+            mobShowChat = builder
+                    .comment("Show the mob lock message in the chat? [Default: false]")
+                    .define("showInChat", false);
+
+            mobShowStagesInChat = builder
+                    .comment("If mobShowChat is true, should the required stages also be listed? [Default: true]")
+                    .define("showStagesInChat", true);
+            builder.pop();
 
             // --- NOTIFICATIONS SECTION ---
             builder.comment("Global Notification Settings (Server-controlled)").push("notifications");

--- a/src/main/java/net/bananemdnsa/historystages/client/editor/ConfigEditorScreen.java
+++ b/src/main/java/net/bananemdnsa/historystages/client/editor/ConfigEditorScreen.java
@@ -169,30 +169,6 @@ public class ConfigEditorScreen extends Screen {
                 "Hide already fulfilled dependencies in scroll tooltips?"));
         clientSections.add(dependenciesClient);
 
-        ConfigSection dimLock = new ConfigSection("editor.historystages.config.dimension_lock");
-        dimLock.add(new ConfigEntry("dimUseActionbar", ConfigType.BOOLEAN,
-                Config.CLIENT.dimUseActionbar.get().toString(), true, "true",
-                "Show a simple 'Dimension Locked' message in the actionbar?"));
-        dimLock.add(new ConfigEntry("dimShowChat", ConfigType.BOOLEAN,
-                Config.CLIENT.dimShowChat.get().toString(), true, "false",
-                "Show the dimension lock message in the chat?"));
-        dimLock.add(new ConfigEntry("dimShowStagesInChat", ConfigType.BOOLEAN,
-                Config.CLIENT.dimShowStagesInChat.get().toString(), true, "true",
-                "If dimShowChat is true, should the required stages also be listed?"));
-        clientSections.add(dimLock);
-
-        ConfigSection mobLock = new ConfigSection("editor.historystages.config.mob_lock");
-        mobLock.add(new ConfigEntry("mobUseActionbar", ConfigType.BOOLEAN,
-                Config.CLIENT.mobUseActionbar.get().toString(), true, "true",
-                "Show a 'Mob Protected' message in the actionbar?"));
-        mobLock.add(new ConfigEntry("mobShowChat", ConfigType.BOOLEAN,
-                Config.CLIENT.mobShowChat.get().toString(), true, "false",
-                "Show the mob lock message in the chat?"));
-        mobLock.add(new ConfigEntry("mobShowStagesInChat", ConfigType.BOOLEAN,
-                Config.CLIENT.mobShowStagesInChat.get().toString(), true, "true",
-                "If mobShowChat is true, should the required stages also be listed?"));
-        clientSections.add(mobLock);
-
         // --- COMMON CONFIG ---
         commonSections = new ArrayList<>();
 
@@ -228,6 +204,30 @@ public class ConfigEditorScreen extends Screen {
                 Config.COMMON.lockBlockInteraction.get().toString(), false, "true",
                 "Prevent opening the GUI of locked blocks? (Chests, furnaces, crafting tables, etc.)"));
         commonSections.add(gameplay);
+
+        ConfigSection dimLock = new ConfigSection("editor.historystages.config.dimension_lock");
+        dimLock.add(new ConfigEntry("dimUseActionbar", ConfigType.BOOLEAN,
+                Config.COMMON.dimUseActionbar.get().toString(), false, "true",
+                "Show a simple 'Dimension Locked' message in the actionbar?"));
+        dimLock.add(new ConfigEntry("dimShowChat", ConfigType.BOOLEAN,
+                Config.COMMON.dimShowChat.get().toString(), false, "false",
+                "Show the dimension lock message in the chat?"));
+        dimLock.add(new ConfigEntry("dimShowStagesInChat", ConfigType.BOOLEAN,
+                Config.COMMON.dimShowStagesInChat.get().toString(), false, "true",
+                "If dimShowChat is true, should the required stages also be listed?"));
+        commonSections.add(dimLock);
+
+        ConfigSection mobLock = new ConfigSection("editor.historystages.config.mob_lock");
+        mobLock.add(new ConfigEntry("mobUseActionbar", ConfigType.BOOLEAN,
+                Config.COMMON.mobUseActionbar.get().toString(), false, "true",
+                "Show a 'Mob Protected' message in the actionbar?"));
+        mobLock.add(new ConfigEntry("mobShowChat", ConfigType.BOOLEAN,
+                Config.COMMON.mobShowChat.get().toString(), false, "false",
+                "Show the mob lock message in the chat?"));
+        mobLock.add(new ConfigEntry("mobShowStagesInChat", ConfigType.BOOLEAN,
+                Config.COMMON.mobShowStagesInChat.get().toString(), false, "true",
+                "If mobShowChat is true, should the required stages also be listed?"));
+        commonSections.add(mobLock);
 
         ConfigSection notifications = new ConfigSection("editor.historystages.config.notifications");
         notifications.add(new ConfigEntry("broadcastChat", ConfigType.BOOLEAN,
@@ -868,16 +868,10 @@ public class ConfigEditorScreen extends Screen {
                 case "showStageName" -> Config.CLIENT.showStageName.set(Boolean.parseBoolean(value));
                 case "showAllUntilComplete" -> Config.CLIENT.showAllUntilComplete.set(Boolean.parseBoolean(value));
                 case "showLockIcons" -> Config.CLIENT.showLockIcons.set(Boolean.parseBoolean(value));
-                case "dimUseActionbar" -> Config.CLIENT.dimUseActionbar.set(Boolean.parseBoolean(value));
-                case "dimShowChat" -> Config.CLIENT.dimShowChat.set(Boolean.parseBoolean(value));
-                case "dimShowStagesInChat" -> Config.CLIENT.dimShowStagesInChat.set(Boolean.parseBoolean(value));
                 case "jadeShowInfo" -> Config.CLIENT.jadeShowInfo.set(Boolean.parseBoolean(value));
                 case "jadeStageName" -> Config.CLIENT.jadeStageName.set(Boolean.parseBoolean(value));
                 case "jadeShowAllUntilComplete" ->
                     Config.CLIENT.jadeShowAllUntilComplete.set(Boolean.parseBoolean(value));
-                case "mobUseActionbar" -> Config.CLIENT.mobUseActionbar.set(Boolean.parseBoolean(value));
-                case "mobShowChat" -> Config.CLIENT.mobShowChat.set(Boolean.parseBoolean(value));
-                case "mobShowStagesInChat" -> Config.CLIENT.mobShowStagesInChat.set(Boolean.parseBoolean(value));
                 case "showSilverLockIcons" -> Config.CLIENT.showSilverLockIcons.set(Boolean.parseBoolean(value));
                 case "showIndividualTooltips" -> Config.CLIENT.showIndividualTooltips.set(Boolean.parseBoolean(value));
                 case "showDependenciesOnScroll" ->

--- a/src/main/java/net/bananemdnsa/historystages/events/DimensionLockHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/events/DimensionLockHandler.java
@@ -56,9 +56,9 @@ public class DimensionLockHandler {
             DebugLogger.runtime("Dimension Lock", player.getName().getString(),
                     "Blocked travel to '" + dimId + "' — missing stages: " + lockedStages);
 
-            if (Config.CLIENT.dimShowChat.get()) {
+            if (Config.COMMON.dimShowChat.get()) {
                 MutableComponent chatMsg = Component.translatable("message.historystages.dimension_locked");
-                if (Config.CLIENT.dimShowStagesInChat.get()) {
+                if (Config.COMMON.dimShowStagesInChat.get()) {
                     for (String stageId : lockedStages) {
                         StageEntry stageEntry = StageManager.getStages().get(stageId);
                         if (stageEntry == null) {
@@ -71,7 +71,7 @@ public class DimensionLockHandler {
                 player.sendSystemMessage(chatMsg);
             }
 
-            if (Config.CLIENT.dimUseActionbar.get()) {
+            if (Config.COMMON.dimUseActionbar.get()) {
                 player.displayClientMessage(
                         Component.translatable("message.historystages.dimension_unknown")
                                 .withStyle(ChatFormatting.DARK_RED, ChatFormatting.ITALIC),

--- a/src/main/java/net/bananemdnsa/historystages/events/MobLockHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/events/MobLockHandler.java
@@ -72,9 +72,9 @@ public class MobLockHandler {
             if (lastMessage != null && (now - lastMessage) < COOLDOWN_MS) return;
             MESSAGE_COOLDOWNS.put(player.getUUID(), now);
 
-            if (Config.CLIENT.mobShowChat.get()) {
+            if (Config.COMMON.mobShowChat.get()) {
                 MutableComponent chatMsg = Component.translatable("message.historystages.mob_locked");
-                if (Config.CLIENT.mobShowStagesInChat.get()) {
+                if (Config.COMMON.mobShowStagesInChat.get()) {
                     for (String stageId : lockedStages) {
                         StageEntry stageEntry = StageManager.getStages().get(stageId);
                         String displayName = (stageEntry != null) ? stageEntry.getDisplayName() : stageId;
@@ -84,7 +84,7 @@ public class MobLockHandler {
                 player.sendSystemMessage(chatMsg);
             }
 
-            if (Config.CLIENT.mobUseActionbar.get()) {
+            if (Config.COMMON.mobUseActionbar.get()) {
                 player.displayClientMessage(
                         Component.translatable("message.historystages.mob_unknown")
                                 .withStyle(ChatFormatting.DARK_RED, ChatFormatting.ITALIC),

--- a/src/main/java/net/bananemdnsa/historystages/network/SaveConfigPacket.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/SaveConfigPacket.java
@@ -76,6 +76,12 @@ public class SaveConfigPacket {
                 case "lockItemUsage" -> Config.COMMON.lockItemUsage.set(Boolean.parseBoolean(value));
                 case "lockEntityItems" -> Config.COMMON.lockEntityItems.set(Boolean.parseBoolean(value));
                 case "lockBlockInteraction" -> Config.COMMON.lockBlockInteraction.set(Boolean.parseBoolean(value));
+                case "dimUseActionbar" -> Config.COMMON.dimUseActionbar.set(Boolean.parseBoolean(value));
+                case "dimShowChat" -> Config.COMMON.dimShowChat.set(Boolean.parseBoolean(value));
+                case "dimShowStagesInChat" -> Config.COMMON.dimShowStagesInChat.set(Boolean.parseBoolean(value));
+                case "mobUseActionbar" -> Config.COMMON.mobUseActionbar.set(Boolean.parseBoolean(value));
+                case "mobShowChat" -> Config.COMMON.mobShowChat.set(Boolean.parseBoolean(value));
+                case "mobShowStagesInChat" -> Config.COMMON.mobShowStagesInChat.set(Boolean.parseBoolean(value));
                 case "broadcastChat" -> Config.COMMON.broadcastChat.set(Boolean.parseBoolean(value));
                 case "unlockMessageFormat" -> Config.COMMON.unlockMessageFormat.set(value);
                 case "useActionbar" -> Config.COMMON.useActionbar.set(Boolean.parseBoolean(value));

--- a/src/main/java/net/bananemdnsa/historystages/network/SyncConfigPacket.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/SyncConfigPacket.java
@@ -58,6 +58,12 @@ public class SyncConfigPacket {
         values.put("lockedBlockBreakSpeedMultiplier", Config.COMMON.lockedBlockBreakSpeedMultiplier.get().toString());
         values.put("lockItemUsage", Config.COMMON.lockItemUsage.get().toString());
         values.put("lockEntityItems", Config.COMMON.lockEntityItems.get().toString());
+        values.put("dimUseActionbar", Config.COMMON.dimUseActionbar.get().toString());
+        values.put("dimShowChat", Config.COMMON.dimShowChat.get().toString());
+        values.put("dimShowStagesInChat", Config.COMMON.dimShowStagesInChat.get().toString());
+        values.put("mobUseActionbar", Config.COMMON.mobUseActionbar.get().toString());
+        values.put("mobShowChat", Config.COMMON.mobShowChat.get().toString());
+        values.put("mobShowStagesInChat", Config.COMMON.mobShowStagesInChat.get().toString());
         values.put("broadcastChat", Config.COMMON.broadcastChat.get().toString());
         values.put("unlockMessageFormat", Config.COMMON.unlockMessageFormat.get());
         values.put("useActionbar", Config.COMMON.useActionbar.get().toString());


### PR DESCRIPTION
## Description
Fixes a crash on dedicated servers when a player tries to enter a locked dimension.  
The dimension and mob lock feedback settings are now read from the common config instead of the client config.

Try it out and see if it works now. I couldn't test it with your entire modpack, though.

Liebe Grüße

## Type of Change
- [x] Bug fix

## Testing
- [ ] Tested on a dedicated server
- [ ] Tested in singleplayer
- [ ] Tested with JEI / EMI (if affected)
- [ ] Tested with FTBQuests (if affected)
- [ ] Tested with KubeJS / CraftTweaker (if affected)

## Checklist
- [x] Code compiles without errors (`./gradlew compileJava`)
- [x] No unintended changes to unrelated files
- [ ] Existing stage JSON configs still work as expected
- [ ] Changelog / version number updated (if applicable)

## Screenshots / Videos

## Additional Notes
Not tested with the full mod list from the report.