### PR TITLE
Wip structure lock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,14 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
 
+      - name: Compute artifact name
+        id: artifact
+        run: |
+          REF="${{ github.head_ref || github.ref_name }}"
+          echo "name=History-Stages-${REF//\//-}" >> "$GITHUB_OUTPUT"
+
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: History-Stages-${{ github.ref_name }}
+          name: ${{ steps.artifact.outputs.name }}
           path: build/libs/*.jar

--- a/src/main/java/net/bananemdnsa/historystages/Config.java
+++ b/src/main/java/net/bananemdnsa/historystages/Config.java
@@ -188,6 +188,8 @@ public class Config {
         public final ModConfigSpec.BooleanValue structureMessageEnabled;
         public final ModConfigSpec.ConfigValue<String> structureLockMessageFormat;
         public final ModConfigSpec.BooleanValue structureLockInChat;
+        public final ModConfigSpec.IntValue structureLockPadding;
+        public final ModConfigSpec.IntValue structureClusterDistance;
 
         // Lock-Message Overrides (leer = Translation Key wird verwendet)
         public final ModConfigSpec.ConfigValue<String> msgDimensionUnknown;
@@ -395,6 +397,26 @@ public class Config {
             structureDamageInterval = builder
                     .comment("How often (in ticks) to deal damage while inside a locked structure. [Default: 20]")
                     .defineInRange("damageInterval", 20, 1, 600);
+
+            structureLockPadding = builder
+                    .comment(
+                            "ADVANCED — leave this alone if you don't know what it does.",
+                            "Extra blocks added around each piece of a locked structure (rooms, corridors, houses, ...).",
+                            "Higher values = the lock 'kicks in' a bit before you actually touch the structure wall,",
+                            "lower values = the boundary sits exactly on the blocks. Measured in blocks. [Default: 1]"
+                    )
+                    .defineInRange("lockPadding", 1, 0, 16);
+
+            structureClusterDistance = builder
+                    .comment(
+                            "ADVANCED — leave this alone if you don't know what it does.",
+                            "How far apart (in blocks) two pieces of the same structure can be while still being",
+                            "joined into one connected lock zone. Example for a village: with a low value, each",
+                            "house is its own little zone and the gaps between houses are walkable; with a higher",
+                            "value, neighbouring houses + paths fuse into one lock zone covering the whole area.",
+                            "Higher = larger, more 'filled-in' lock zones. Lower = more precise, more gaps. [Default: 6]"
+                    )
+                    .defineInRange("clusterDistance", 6, 0, 32);
 
             builder.pop(); // structure_lock
 

--- a/src/main/java/net/bananemdnsa/historystages/Config.java
+++ b/src/main/java/net/bananemdnsa/historystages/Config.java
@@ -22,6 +22,8 @@ public class Config {
         public final ModConfigSpec.BooleanValue showLockIcons;
         public final ModConfigSpec.BooleanValue structureBorderEnabled;
         public final ModConfigSpec.DoubleValue structureBorderDistance;
+        public final ModConfigSpec.BooleanValue structureLockOverlayEnabled;
+        public final ModConfigSpec.DoubleValue structureLockOverlayOpacity;
         public final ModConfigSpec.BooleanValue mobUseActionbar;
         public final ModConfigSpec.BooleanValue mobShowChat;
         public final ModConfigSpec.BooleanValue mobShowStagesInChat;
@@ -65,6 +67,14 @@ public class Config {
             structureBorderDistance = builder
                     .comment("How close (in blocks) to a locked structure wall before the border becomes visible. The border fades in as you approach. [Default: 8.0]")
                     .defineInRange("structureBorderDistance", 8.0, 1.0, 32.0);
+
+            structureLockOverlayEnabled = builder
+                    .comment("While standing inside a locked structure, tint the whole screen red (like looking through red glasses) to signal the lock? [Default: true]")
+                    .define("structureLockOverlayEnabled", true);
+
+            structureLockOverlayOpacity = builder
+                    .comment("Opacity of the red lock-overlay (0.0 = invisible, 1.0 = fully opaque). [Default: 0.30]")
+                    .defineInRange("structureLockOverlayOpacity", 0.30, 0.0, 1.0);
 
             builder.pop();
 
@@ -412,10 +422,11 @@ public class Config {
                     .comment(
                             "ADVANCED — leave this alone if you don't know what it does.",
                             "Extra blocks added around each piece of a locked structure (rooms, corridors, houses, ...).",
-                            "Higher values = the lock 'kicks in' a bit before you actually touch the structure wall,",
-                            "lower values = the boundary sits exactly on the blocks. Measured in blocks. [Default: 1]"
+                            "Note: a fixed safety buffer of 2 blocks is ALWAYS added on top of this value, so",
+                            "the effective padding around structure walls is (lockPadding + 2). Setting this to 0",
+                            "still leaves a 2-block safety wall between you and the structure. [Default: 0]"
                     )
-                    .defineInRange("lockPadding", 1, 0, 16);
+                    .defineInRange("lockPadding", 0, 0, 16);
 
             structureClusterDistance = builder
                     .comment(

--- a/src/main/java/net/bananemdnsa/historystages/Config.java
+++ b/src/main/java/net/bananemdnsa/historystages/Config.java
@@ -212,6 +212,8 @@ public class Config {
         public final ModConfigSpec.IntValue structureClusterDistance;
         public final ModConfigSpec.BooleanValue structureBlockRightClick;
         public final ModConfigSpec.BooleanValue structureBlockLeftClick;
+        public final ModConfigSpec.BooleanValue structureWallMode;
+        public final ModConfigSpec.BooleanValue structureBlockProjectiles;
 
         // Lock-Message Overrides (leer = Translation Key wird verwendet)
         public final ModConfigSpec.ConfigValue<String> msgDimensionUnknown;
@@ -448,6 +450,19 @@ public class Config {
             structureBlockLeftClick = builder
                     .comment("Cancel ALL left-click interactions (attacking entities, breaking blocks) while the player is inside a locked structure? [Default: true]")
                     .define("blockLeftClick", true);
+
+            structureWallMode = builder
+                    .comment(
+                            "Lock behavior:",
+                            "  true  = WALL mode: an invisible wall blocks entry; players are pushed back at the boundary.",
+                            "  false = DAMAGE mode: players can walk in but take damage / see the red overlay / get messages.",
+                            "Wall mode is the recommended default; damage mode is the legacy behavior. [Default: true]"
+                    )
+                    .define("wallMode", true);
+
+            structureBlockProjectiles = builder
+                    .comment("Cancel projectiles (arrows, snowballs, ender pearls, etc.) the moment they would impact something inside a locked structure? [Default: true]")
+                    .define("blockProjectiles", true);
 
             builder.pop(); // structure_lock
 

--- a/src/main/java/net/bananemdnsa/historystages/Config.java
+++ b/src/main/java/net/bananemdnsa/historystages/Config.java
@@ -212,7 +212,6 @@ public class Config {
         public final ModConfigSpec.IntValue structureClusterDistance;
         public final ModConfigSpec.BooleanValue structureBlockRightClick;
         public final ModConfigSpec.BooleanValue structureBlockLeftClick;
-        public final ModConfigSpec.BooleanValue structureWallMode;
         public final ModConfigSpec.BooleanValue structureBlockProjectiles;
 
         // Lock-Message Overrides (leer = Translation Key wird verwendet)
@@ -450,15 +449,6 @@ public class Config {
             structureBlockLeftClick = builder
                     .comment("Cancel ALL left-click interactions (attacking entities, breaking blocks) while the player is inside a locked structure? [Default: true]")
                     .define("blockLeftClick", true);
-
-            structureWallMode = builder
-                    .comment(
-                            "Lock behavior:",
-                            "  true  = WALL mode: an invisible wall blocks entry; players are pushed back at the boundary.",
-                            "  false = DAMAGE mode: players can walk in but take damage / see the red overlay / get messages.",
-                            "Wall mode is the recommended default; damage mode is the legacy behavior. [Default: true]"
-                    )
-                    .define("wallMode", true);
 
             structureBlockProjectiles = builder
                     .comment("Cancel projectiles (arrows, snowballs, ender pearls, etc.) the moment they would impact something inside a locked structure? [Default: true]")

--- a/src/main/java/net/bananemdnsa/historystages/Config.java
+++ b/src/main/java/net/bananemdnsa/historystages/Config.java
@@ -210,6 +210,8 @@ public class Config {
         public final ModConfigSpec.BooleanValue structureLockInChat;
         public final ModConfigSpec.IntValue structureLockPadding;
         public final ModConfigSpec.IntValue structureClusterDistance;
+        public final ModConfigSpec.BooleanValue structureBlockRightClick;
+        public final ModConfigSpec.BooleanValue structureBlockLeftClick;
 
         // Lock-Message Overrides (leer = Translation Key wird verwendet)
         public final ModConfigSpec.ConfigValue<String> msgDimensionUnknown;
@@ -438,6 +440,14 @@ public class Config {
                             "Higher = larger, more 'filled-in' lock zones. Lower = more precise, more gaps. [Default: 6]"
                     )
                     .defineInRange("clusterDistance", 6, 0, 32);
+
+            structureBlockRightClick = builder
+                    .comment("Cancel ALL right-click interactions (blocks, items, entities) while the player is inside a locked structure? [Default: true]")
+                    .define("blockRightClick", true);
+
+            structureBlockLeftClick = builder
+                    .comment("Cancel ALL left-click interactions (attacking entities, breaking blocks) while the player is inside a locked structure? [Default: true]")
+                    .define("blockLeftClick", true);
 
             builder.pop(); // structure_lock
 

--- a/src/main/java/net/bananemdnsa/historystages/Config.java
+++ b/src/main/java/net/bananemdnsa/historystages/Config.java
@@ -20,6 +20,8 @@ public class Config {
         public final ModConfigSpec.BooleanValue dimShowChat;
         public final ModConfigSpec.BooleanValue dimShowStagesInChat;
         public final ModConfigSpec.BooleanValue showLockIcons;
+        public final ModConfigSpec.BooleanValue structureBorderEnabled;
+        public final ModConfigSpec.DoubleValue structureBorderDistance;
         public final ModConfigSpec.BooleanValue mobUseActionbar;
         public final ModConfigSpec.BooleanValue mobShowChat;
         public final ModConfigSpec.BooleanValue mobShowStagesInChat;
@@ -55,6 +57,14 @@ public class Config {
             showLockIcons = builder
                     .comment("Show a lock icon overlay on locked items in JEI and Inventories? (Will be disabled if EMI is installed) [Default: true]")
                     .define("showLockIcons", true);
+
+            structureBorderEnabled = builder
+                    .comment("Render a force-field-style border on the walls of locked structures when you get close? [Default: true]")
+                    .define("structureBorderEnabled", true);
+
+            structureBorderDistance = builder
+                    .comment("How close (in blocks) to a locked structure wall before the border becomes visible. The border fades in as you approach. [Default: 8.0]")
+                    .defineInRange("structureBorderDistance", 8.0, 1.0, 32.0);
 
             builder.pop();
 

--- a/src/main/java/net/bananemdnsa/historystages/client/LockBorderClientCache.java
+++ b/src/main/java/net/bananemdnsa/historystages/client/LockBorderClientCache.java
@@ -1,0 +1,28 @@
+package net.bananemdnsa.historystages.client;
+
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+
+import java.util.List;
+
+/**
+ * Client-side cache of locked-structure bounding boxes pushed by the server.
+ * Read each frame by the lock-border renderer.
+ */
+public final class LockBorderClientCache {
+
+    private static volatile List<BoundingBox> boxes = List.of();
+
+    private LockBorderClientCache() {}
+
+    public static List<BoundingBox> get() {
+        return boxes;
+    }
+
+    public static void set(List<BoundingBox> next) {
+        boxes = next == null ? List.of() : List.copyOf(next);
+    }
+
+    public static void clear() {
+        boxes = List.of();
+    }
+}

--- a/src/main/java/net/bananemdnsa/historystages/client/LockBorderRenderer.java
+++ b/src/main/java/net/bananemdnsa/historystages/client/LockBorderRenderer.java
@@ -1,0 +1,223 @@
+package net.bananemdnsa.historystages.client;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.BufferUploader;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.MeshData;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.bananemdnsa.historystages.Config;
+import net.bananemdnsa.historystages.HistoryStages;
+import net.minecraft.Util;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import org.joml.Matrix4f;
+
+import java.util.List;
+
+/**
+ * Draws a force-field "patch" on the faces of locked-structure bounding boxes
+ * cached by {@link LockBorderClientCache}. Instead of covering the whole face,
+ * only a square region around the player's projection onto the face is rendered;
+ * the patch radius grows as the player approaches the wall.
+ *
+ * <p>UV mapping is world-anchored (texture stays put on the wall as the player moves)
+ * with a slow time-based scroll for the classic force-field animation.
+ */
+@EventBusSubscriber(modid = HistoryStages.MOD_ID, value = Dist.CLIENT)
+public final class LockBorderRenderer {
+
+    private static final ResourceLocation FORCEFIELD =
+            ResourceLocation.parse("minecraft:textures/misc/forcefield.png");
+
+    /** How many blocks one texture tile covers. Smaller = more tiling on the wall. */
+    private static final float TILE_BLOCKS = 4.0f;
+
+    /** Alpha of the patch center; falls off linearly with distance from camera. */
+    private static final float CENTER_ALPHA = 0.7f;
+
+    private LockBorderRenderer() {}
+
+    @SubscribeEvent
+    public static void onRenderLevel(RenderLevelStageEvent event) {
+        if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) return;
+        if (!Config.CLIENT.structureBorderEnabled.get()) return;
+
+        List<BoundingBox> boxes = LockBorderClientCache.get();
+        if (boxes.isEmpty()) return;
+
+        double threshold = Config.CLIENT.structureBorderDistance.get();
+
+        Vec3 cam = event.getCamera().getPosition();
+        float scroll = (float) ((Util.getMillis() % 3000L) / 3000.0);
+
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        RenderSystem.depthMask(false);
+        RenderSystem.disableDepthTest();
+        RenderSystem.disableCull();
+        RenderSystem.setShader(GameRenderer::getPositionTexColorShader);
+        RenderSystem.setShaderTexture(0, FORCEFIELD);
+
+        PoseStack pose = event.getPoseStack();
+        pose.pushPose();
+        pose.translate(-cam.x, -cam.y, -cam.z);
+        Matrix4f matrix = pose.last().pose();
+
+        BufferBuilder buffer = Tesselator.getInstance().begin(
+                VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
+
+        for (BoundingBox bb : boxes) {
+            renderBox(buffer, matrix, bb, cam, threshold, scroll);
+        }
+
+        MeshData mesh = buffer.build();
+        if (mesh != null) {
+            BufferUploader.drawWithShader(mesh);
+        }
+
+        pose.popPose();
+
+        RenderSystem.enableCull();
+        RenderSystem.enableDepthTest();
+        RenderSystem.depthMask(true);
+        RenderSystem.disableBlend();
+    }
+
+    private static void renderBox(BufferBuilder buf, Matrix4f m, BoundingBox bb,
+                                   Vec3 cam, double threshold, float scroll) {
+        float x0 = bb.minX();
+        float y0 = bb.minY();
+        float z0 = bb.minZ();
+        float x1 = bb.maxX() + 1.0f;
+        float y1 = bb.maxY() + 1.0f;
+        float z1 = bb.maxZ() + 1.0f;
+
+        // Cheap broad-phase: closest point of the box to the camera.
+        double cx = clamp(cam.x, x0, x1);
+        double cy = clamp(cam.y, y0, y1);
+        double cz = clamp(cam.z, z0, z1);
+        double dx = cam.x - cx, dy = cam.y - cy, dz = cam.z - cz;
+        double boxDistSq = dx * dx + dy * dy + dz * dz;
+        if (boxDistSq > threshold * threshold) return;
+
+        // Faces with normals along X (west / east) — vary in Y and Z.
+        renderFaceX(buf, m, x0, y0, y1, z0, z1, cam, threshold, scroll);
+        renderFaceX(buf, m, x1, y0, y1, z0, z1, cam, threshold, scroll);
+        // Faces with normals along Y (bottom / top) — vary in X and Z.
+        renderFaceY(buf, m, y0, x0, x1, z0, z1, cam, threshold, scroll);
+        renderFaceY(buf, m, y1, x0, x1, z0, z1, cam, threshold, scroll);
+        // Faces with normals along Z (north / south) — vary in X and Y.
+        renderFaceZ(buf, m, z0, x0, x1, y0, y1, cam, threshold, scroll);
+        renderFaceZ(buf, m, z1, x0, x1, y0, y1, cam, threshold, scroll);
+    }
+
+    private static void renderFaceX(BufferBuilder buf, Matrix4f m,
+                                     float planeX, float minY, float maxY, float minZ, float maxZ,
+                                     Vec3 cam, double threshold, float scroll) {
+        double py = clamp(cam.y, minY, maxY);
+        double pz = clamp(cam.z, minZ, maxZ);
+        double ddx = cam.x - planeX, ddy = cam.y - py, ddz = cam.z - pz;
+        double dist = Math.sqrt(ddx * ddx + ddy * ddy + ddz * ddz);
+        if (dist > threshold) return;
+
+        float radius = (float) ((1.0 - dist / threshold) * threshold);
+        if (radius <= 0) return;
+
+        float patchMinY = Math.max(minY, (float) py - radius);
+        float patchMaxY = Math.min(maxY, (float) py + radius);
+        float patchMinZ = Math.max(minZ, (float) pz - radius);
+        float patchMaxZ = Math.min(maxZ, (float) pz + radius);
+        if (patchMinY >= patchMaxY || patchMinZ >= patchMaxZ) return;
+
+        int alpha = alphaForDist(dist, threshold);
+        float uMin = patchMinZ / TILE_BLOCKS + scroll;
+        float uMax = patchMaxZ / TILE_BLOCKS + scroll;
+        float vMin = patchMinY / TILE_BLOCKS - scroll;
+        float vMax = patchMaxY / TILE_BLOCKS - scroll;
+
+        buf.addVertex(m, planeX, patchMinY, patchMinZ).setUv(uMin, vMin).setColor(255, 255, 255, alpha);
+        buf.addVertex(m, planeX, patchMinY, patchMaxZ).setUv(uMax, vMin).setColor(255, 255, 255, alpha);
+        buf.addVertex(m, planeX, patchMaxY, patchMaxZ).setUv(uMax, vMax).setColor(255, 255, 255, alpha);
+        buf.addVertex(m, planeX, patchMaxY, patchMinZ).setUv(uMin, vMax).setColor(255, 255, 255, alpha);
+    }
+
+    private static void renderFaceY(BufferBuilder buf, Matrix4f m,
+                                     float planeY, float minX, float maxX, float minZ, float maxZ,
+                                     Vec3 cam, double threshold, float scroll) {
+        double px = clamp(cam.x, minX, maxX);
+        double pz = clamp(cam.z, minZ, maxZ);
+        double ddx = cam.x - px, ddy = cam.y - planeY, ddz = cam.z - pz;
+        double dist = Math.sqrt(ddx * ddx + ddy * ddy + ddz * ddz);
+        if (dist > threshold) return;
+
+        float radius = (float) ((1.0 - dist / threshold) * threshold);
+        if (radius <= 0) return;
+
+        float patchMinX = Math.max(minX, (float) px - radius);
+        float patchMaxX = Math.min(maxX, (float) px + radius);
+        float patchMinZ = Math.max(minZ, (float) pz - radius);
+        float patchMaxZ = Math.min(maxZ, (float) pz + radius);
+        if (patchMinX >= patchMaxX || patchMinZ >= patchMaxZ) return;
+
+        int alpha = alphaForDist(dist, threshold);
+        float uMin = patchMinX / TILE_BLOCKS + scroll;
+        float uMax = patchMaxX / TILE_BLOCKS + scroll;
+        float vMin = patchMinZ / TILE_BLOCKS - scroll;
+        float vMax = patchMaxZ / TILE_BLOCKS - scroll;
+
+        buf.addVertex(m, patchMinX, planeY, patchMinZ).setUv(uMin, vMin).setColor(255, 255, 255, alpha);
+        buf.addVertex(m, patchMaxX, planeY, patchMinZ).setUv(uMax, vMin).setColor(255, 255, 255, alpha);
+        buf.addVertex(m, patchMaxX, planeY, patchMaxZ).setUv(uMax, vMax).setColor(255, 255, 255, alpha);
+        buf.addVertex(m, patchMinX, planeY, patchMaxZ).setUv(uMin, vMax).setColor(255, 255, 255, alpha);
+    }
+
+    private static void renderFaceZ(BufferBuilder buf, Matrix4f m,
+                                     float planeZ, float minX, float maxX, float minY, float maxY,
+                                     Vec3 cam, double threshold, float scroll) {
+        double px = clamp(cam.x, minX, maxX);
+        double py = clamp(cam.y, minY, maxY);
+        double ddx = cam.x - px, ddy = cam.y - py, ddz = cam.z - planeZ;
+        double dist = Math.sqrt(ddx * ddx + ddy * ddy + ddz * ddz);
+        if (dist > threshold) return;
+
+        float radius = (float) ((1.0 - dist / threshold) * threshold);
+        if (radius <= 0) return;
+
+        float patchMinX = Math.max(minX, (float) px - radius);
+        float patchMaxX = Math.min(maxX, (float) px + radius);
+        float patchMinY = Math.max(minY, (float) py - radius);
+        float patchMaxY = Math.min(maxY, (float) py + radius);
+        if (patchMinX >= patchMaxX || patchMinY >= patchMaxY) return;
+
+        int alpha = alphaForDist(dist, threshold);
+        float uMin = patchMinX / TILE_BLOCKS + scroll;
+        float uMax = patchMaxX / TILE_BLOCKS + scroll;
+        float vMin = patchMinY / TILE_BLOCKS - scroll;
+        float vMax = patchMaxY / TILE_BLOCKS - scroll;
+
+        buf.addVertex(m, patchMinX, patchMinY, planeZ).setUv(uMin, vMin).setColor(255, 255, 255, alpha);
+        buf.addVertex(m, patchMaxX, patchMinY, planeZ).setUv(uMax, vMin).setColor(255, 255, 255, alpha);
+        buf.addVertex(m, patchMaxX, patchMaxY, planeZ).setUv(uMax, vMax).setColor(255, 255, 255, alpha);
+        buf.addVertex(m, patchMinX, patchMaxY, planeZ).setUv(uMin, vMax).setColor(255, 255, 255, alpha);
+    }
+
+    private static int alphaForDist(double dist, double threshold) {
+        double t = 1.0 - dist / threshold;
+        if (t < 0) t = 0;
+        if (t > 1) t = 1;
+        return Math.max(0, Math.min(255, (int) (CENTER_ALPHA * t * 255.0)));
+    }
+
+    private static double clamp(double v, double lo, double hi) {
+        return v < lo ? lo : Math.min(v, hi);
+    }
+}

--- a/src/main/java/net/bananemdnsa/historystages/client/LockBorderRenderer.java
+++ b/src/main/java/net/bananemdnsa/historystages/client/LockBorderRenderer.java
@@ -24,13 +24,14 @@ import org.joml.Matrix4f;
 import java.util.List;
 
 /**
- * Draws a force-field "patch" on the faces of locked-structure bounding boxes
- * cached by {@link LockBorderClientCache}. Instead of covering the whole face,
- * only a square region around the player's projection onto the face is rendered;
- * the patch radius grows as the player approaches the wall.
+ * Draws a force-field "patch" on the faces of the orange lock zone — the union of all
+ * {@link BoundingBox}es pushed by the server. Each face is subdivided into 1-block cells
+ * and a cell is only drawn if its exterior side is not occluded by another shape in the
+ * zone, so the texture traces the silhouette of the union instead of every individual box.
  *
- * <p>UV mapping is world-anchored (texture stays put on the wall as the player moves)
- * with a slow time-based scroll for the classic force-field animation.
+ * <p>Only cells near the camera's projection onto each face are drawn (patch reveal —
+ * texture appears as you approach the wall). UV mapping is world-anchored with a slow
+ * time-based scroll for the classic force-field animation.
  */
 @EventBusSubscriber(modid = HistoryStages.MOD_ID, value = Dist.CLIENT)
 public final class LockBorderRenderer {
@@ -42,7 +43,7 @@ public final class LockBorderRenderer {
     private static final float TILE_BLOCKS = 4.0f;
 
     /** Alpha of the patch center; falls off linearly with distance from camera. */
-    private static final float CENTER_ALPHA = 0.7f;
+    private static final float CENTER_ALPHA = 0.9f;
 
     private LockBorderRenderer() {}
 
@@ -62,7 +63,9 @@ public final class LockBorderRenderer {
         RenderSystem.enableBlend();
         RenderSystem.defaultBlendFunc();
         RenderSystem.depthMask(false);
-        RenderSystem.disableDepthTest();
+        // Depth test ON: only the parts of the force-field in front of blocks are drawn.
+        // depthMask(false) keeps us from writing to the depth buffer ourselves.
+        RenderSystem.enableDepthTest();
         RenderSystem.disableCull();
         RenderSystem.setShader(GameRenderer::getPositionTexColorShader);
         RenderSystem.setShaderTexture(0, FORCEFIELD);
@@ -75,8 +78,8 @@ public final class LockBorderRenderer {
         BufferBuilder buffer = Tesselator.getInstance().begin(
                 VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX_COLOR);
 
-        for (BoundingBox bb : boxes) {
-            renderBox(buffer, matrix, bb, cam, threshold, scroll);
+        for (int i = 0; i < boxes.size(); i++) {
+            renderBox(buffer, matrix, boxes, i, boxes.get(i), cam, threshold, scroll);
         }
 
         MeshData mesh = buffer.build();
@@ -92,8 +95,8 @@ public final class LockBorderRenderer {
         RenderSystem.disableBlend();
     }
 
-    private static void renderBox(BufferBuilder buf, Matrix4f m, BoundingBox bb,
-                                   Vec3 cam, double threshold, float scroll) {
+    private static void renderBox(BufferBuilder buf, Matrix4f m, List<BoundingBox> all, int ownerIdx,
+                                   BoundingBox bb, Vec3 cam, double threshold, float scroll) {
         float x0 = bb.minX();
         float y0 = bb.minY();
         float z0 = bb.minZ();
@@ -101,7 +104,7 @@ public final class LockBorderRenderer {
         float y1 = bb.maxY() + 1.0f;
         float z1 = bb.maxZ() + 1.0f;
 
-        // Cheap broad-phase: closest point of the box to the camera.
+        // Broad-phase: skip the whole box if its closest point is beyond the threshold.
         double cx = clamp(cam.x, x0, x1);
         double cy = clamp(cam.y, y0, y1);
         double cz = clamp(cam.z, z0, z1);
@@ -109,20 +112,21 @@ public final class LockBorderRenderer {
         double boxDistSq = dx * dx + dy * dy + dz * dz;
         if (boxDistSq > threshold * threshold) return;
 
-        // Faces with normals along X (west / east) — vary in Y and Z.
-        renderFaceX(buf, m, x0, y0, y1, z0, z1, cam, threshold, scroll);
-        renderFaceX(buf, m, x1, y0, y1, z0, z1, cam, threshold, scroll);
-        // Faces with normals along Y (bottom / top) — vary in X and Z.
-        renderFaceY(buf, m, y0, x0, x1, z0, z1, cam, threshold, scroll);
-        renderFaceY(buf, m, y1, x0, x1, z0, z1, cam, threshold, scroll);
-        // Faces with normals along Z (north / south) — vary in X and Y.
-        renderFaceZ(buf, m, z0, x0, x1, y0, y1, cam, threshold, scroll);
-        renderFaceZ(buf, m, z1, x0, x1, y0, y1, cam, threshold, scroll);
+        // X-normal faces
+        renderFaceX(buf, m, all, ownerIdx, bb, x0, y0, y1, z0, z1, cam, threshold, scroll, -1);
+        renderFaceX(buf, m, all, ownerIdx, bb, x1, y0, y1, z0, z1, cam, threshold, scroll, +1);
+        // Y-normal faces
+        renderFaceY(buf, m, all, ownerIdx, bb, y0, x0, x1, z0, z1, cam, threshold, scroll, -1);
+        renderFaceY(buf, m, all, ownerIdx, bb, y1, x0, x1, z0, z1, cam, threshold, scroll, +1);
+        // Z-normal faces
+        renderFaceZ(buf, m, all, ownerIdx, bb, z0, x0, x1, y0, y1, cam, threshold, scroll, -1);
+        renderFaceZ(buf, m, all, ownerIdx, bb, z1, x0, x1, y0, y1, cam, threshold, scroll, +1);
     }
 
-    private static void renderFaceX(BufferBuilder buf, Matrix4f m,
-                                     float planeX, float minY, float maxY, float minZ, float maxZ,
-                                     Vec3 cam, double threshold, float scroll) {
+    private static void renderFaceX(BufferBuilder buf, Matrix4f m, List<BoundingBox> all, int ownerIdx,
+                                     BoundingBox owner, float planeX, float minY, float maxY,
+                                     float minZ, float maxZ, Vec3 cam, double threshold, float scroll,
+                                     int outwardSign) {
         double py = clamp(cam.y, minY, maxY);
         double pz = clamp(cam.z, minZ, maxZ);
         double ddx = cam.x - planeX, ddy = cam.y - py, ddz = cam.z - pz;
@@ -139,20 +143,42 @@ public final class LockBorderRenderer {
         if (patchMinY >= patchMaxY || patchMinZ >= patchMaxZ) return;
 
         int alpha = alphaForDist(dist, threshold);
-        float uMin = patchMinZ / TILE_BLOCKS + scroll;
-        float uMax = patchMaxZ / TILE_BLOCKS + scroll;
-        float vMin = patchMinY / TILE_BLOCKS - scroll;
-        float vMax = patchMaxY / TILE_BLOCKS - scroll;
+        double sampleX = planeX + outwardSign * 0.5;
 
-        buf.addVertex(m, planeX, patchMinY, patchMinZ).setUv(uMin, vMin).setColor(255, 255, 255, alpha);
-        buf.addVertex(m, planeX, patchMinY, patchMaxZ).setUv(uMax, vMin).setColor(255, 255, 255, alpha);
-        buf.addVertex(m, planeX, patchMaxY, patchMaxZ).setUv(uMax, vMax).setColor(255, 255, 255, alpha);
-        buf.addVertex(m, planeX, patchMaxY, patchMinZ).setUv(uMin, vMax).setColor(255, 255, 255, alpha);
+        int yStart = (int) Math.floor(patchMinY);
+        int yEnd = (int) Math.ceil(patchMaxY);
+        int zStart = (int) Math.floor(patchMinZ);
+        int zEnd = (int) Math.ceil(patchMaxZ);
+
+        for (int yi = yStart; yi < yEnd; yi++) {
+            float cy0 = Math.max(yi, patchMinY);
+            float cy1 = Math.min(yi + 1, patchMaxY);
+            if (cy0 >= cy1) continue;
+            double cellY = (cy0 + cy1) * 0.5;
+            for (int zi = zStart; zi < zEnd; zi++) {
+                float cz0 = Math.max(zi, patchMinZ);
+                float cz1 = Math.min(zi + 1, patchMaxZ);
+                if (cz0 >= cz1) continue;
+                double cellZ = (cz0 + cz1) * 0.5;
+                if (exteriorHidden(all, owner, sampleX, cellY, cellZ)) continue;
+                if (coincidentDuplicateX(all, ownerIdx, planeX, cy0, cy1, cz0, cz1)) continue;
+
+                float uMin = cz0 / TILE_BLOCKS + scroll;
+                float uMax = cz1 / TILE_BLOCKS + scroll;
+                float vMin = cy0 / TILE_BLOCKS - scroll;
+                float vMax = cy1 / TILE_BLOCKS - scroll;
+                buf.addVertex(m, planeX, cy0, cz0).setUv(uMin, vMin).setColor(230, 20, 20, alpha);
+                buf.addVertex(m, planeX, cy0, cz1).setUv(uMax, vMin).setColor(230, 20, 20, alpha);
+                buf.addVertex(m, planeX, cy1, cz1).setUv(uMax, vMax).setColor(230, 20, 20, alpha);
+                buf.addVertex(m, planeX, cy1, cz0).setUv(uMin, vMax).setColor(230, 20, 20, alpha);
+            }
+        }
     }
 
-    private static void renderFaceY(BufferBuilder buf, Matrix4f m,
-                                     float planeY, float minX, float maxX, float minZ, float maxZ,
-                                     Vec3 cam, double threshold, float scroll) {
+    private static void renderFaceY(BufferBuilder buf, Matrix4f m, List<BoundingBox> all, int ownerIdx,
+                                     BoundingBox owner, float planeY, float minX, float maxX,
+                                     float minZ, float maxZ, Vec3 cam, double threshold, float scroll,
+                                     int outwardSign) {
         double px = clamp(cam.x, minX, maxX);
         double pz = clamp(cam.z, minZ, maxZ);
         double ddx = cam.x - px, ddy = cam.y - planeY, ddz = cam.z - pz;
@@ -169,20 +195,42 @@ public final class LockBorderRenderer {
         if (patchMinX >= patchMaxX || patchMinZ >= patchMaxZ) return;
 
         int alpha = alphaForDist(dist, threshold);
-        float uMin = patchMinX / TILE_BLOCKS + scroll;
-        float uMax = patchMaxX / TILE_BLOCKS + scroll;
-        float vMin = patchMinZ / TILE_BLOCKS - scroll;
-        float vMax = patchMaxZ / TILE_BLOCKS - scroll;
+        double sampleY = planeY + outwardSign * 0.5;
 
-        buf.addVertex(m, patchMinX, planeY, patchMinZ).setUv(uMin, vMin).setColor(255, 255, 255, alpha);
-        buf.addVertex(m, patchMaxX, planeY, patchMinZ).setUv(uMax, vMin).setColor(255, 255, 255, alpha);
-        buf.addVertex(m, patchMaxX, planeY, patchMaxZ).setUv(uMax, vMax).setColor(255, 255, 255, alpha);
-        buf.addVertex(m, patchMinX, planeY, patchMaxZ).setUv(uMin, vMax).setColor(255, 255, 255, alpha);
+        int xStart = (int) Math.floor(patchMinX);
+        int xEnd = (int) Math.ceil(patchMaxX);
+        int zStart = (int) Math.floor(patchMinZ);
+        int zEnd = (int) Math.ceil(patchMaxZ);
+
+        for (int xi = xStart; xi < xEnd; xi++) {
+            float cx0 = Math.max(xi, patchMinX);
+            float cx1 = Math.min(xi + 1, patchMaxX);
+            if (cx0 >= cx1) continue;
+            double cellX = (cx0 + cx1) * 0.5;
+            for (int zi = zStart; zi < zEnd; zi++) {
+                float cz0 = Math.max(zi, patchMinZ);
+                float cz1 = Math.min(zi + 1, patchMaxZ);
+                if (cz0 >= cz1) continue;
+                double cellZ = (cz0 + cz1) * 0.5;
+                if (exteriorHidden(all, owner, cellX, sampleY, cellZ)) continue;
+                if (coincidentDuplicateY(all, ownerIdx, planeY, cx0, cx1, cz0, cz1)) continue;
+
+                float uMin = cx0 / TILE_BLOCKS + scroll;
+                float uMax = cx1 / TILE_BLOCKS + scroll;
+                float vMin = cz0 / TILE_BLOCKS - scroll;
+                float vMax = cz1 / TILE_BLOCKS - scroll;
+                buf.addVertex(m, cx0, planeY, cz0).setUv(uMin, vMin).setColor(230, 20, 20, alpha);
+                buf.addVertex(m, cx1, planeY, cz0).setUv(uMax, vMin).setColor(230, 20, 20, alpha);
+                buf.addVertex(m, cx1, planeY, cz1).setUv(uMax, vMax).setColor(230, 20, 20, alpha);
+                buf.addVertex(m, cx0, planeY, cz1).setUv(uMin, vMax).setColor(230, 20, 20, alpha);
+            }
+        }
     }
 
-    private static void renderFaceZ(BufferBuilder buf, Matrix4f m,
-                                     float planeZ, float minX, float maxX, float minY, float maxY,
-                                     Vec3 cam, double threshold, float scroll) {
+    private static void renderFaceZ(BufferBuilder buf, Matrix4f m, List<BoundingBox> all, int ownerIdx,
+                                     BoundingBox owner, float planeZ, float minX, float maxX,
+                                     float minY, float maxY, Vec3 cam, double threshold, float scroll,
+                                     int outwardSign) {
         double px = clamp(cam.x, minX, maxX);
         double py = clamp(cam.y, minY, maxY);
         double ddx = cam.x - px, ddy = cam.y - py, ddz = cam.z - planeZ;
@@ -199,15 +247,102 @@ public final class LockBorderRenderer {
         if (patchMinX >= patchMaxX || patchMinY >= patchMaxY) return;
 
         int alpha = alphaForDist(dist, threshold);
-        float uMin = patchMinX / TILE_BLOCKS + scroll;
-        float uMax = patchMaxX / TILE_BLOCKS + scroll;
-        float vMin = patchMinY / TILE_BLOCKS - scroll;
-        float vMax = patchMaxY / TILE_BLOCKS - scroll;
+        double sampleZ = planeZ + outwardSign * 0.5;
 
-        buf.addVertex(m, patchMinX, patchMinY, planeZ).setUv(uMin, vMin).setColor(255, 255, 255, alpha);
-        buf.addVertex(m, patchMaxX, patchMinY, planeZ).setUv(uMax, vMin).setColor(255, 255, 255, alpha);
-        buf.addVertex(m, patchMaxX, patchMaxY, planeZ).setUv(uMax, vMax).setColor(255, 255, 255, alpha);
-        buf.addVertex(m, patchMinX, patchMaxY, planeZ).setUv(uMin, vMax).setColor(255, 255, 255, alpha);
+        int xStart = (int) Math.floor(patchMinX);
+        int xEnd = (int) Math.ceil(patchMaxX);
+        int yStart = (int) Math.floor(patchMinY);
+        int yEnd = (int) Math.ceil(patchMaxY);
+
+        for (int xi = xStart; xi < xEnd; xi++) {
+            float cx0 = Math.max(xi, patchMinX);
+            float cx1 = Math.min(xi + 1, patchMaxX);
+            if (cx0 >= cx1) continue;
+            double cellX = (cx0 + cx1) * 0.5;
+            for (int yi = yStart; yi < yEnd; yi++) {
+                float cy0 = Math.max(yi, patchMinY);
+                float cy1 = Math.min(yi + 1, patchMaxY);
+                if (cy0 >= cy1) continue;
+                double cellY = (cy0 + cy1) * 0.5;
+                if (exteriorHidden(all, owner, cellX, cellY, sampleZ)) continue;
+                if (coincidentDuplicateZ(all, ownerIdx, planeZ, cx0, cx1, cy0, cy1)) continue;
+
+                float uMin = cx0 / TILE_BLOCKS + scroll;
+                float uMax = cx1 / TILE_BLOCKS + scroll;
+                float vMin = cy0 / TILE_BLOCKS - scroll;
+                float vMax = cy1 / TILE_BLOCKS - scroll;
+                buf.addVertex(m, cx0, cy0, planeZ).setUv(uMin, vMin).setColor(230, 20, 20, alpha);
+                buf.addVertex(m, cx1, cy0, planeZ).setUv(uMax, vMin).setColor(230, 20, 20, alpha);
+                buf.addVertex(m, cx1, cy1, planeZ).setUv(uMax, vMax).setColor(230, 20, 20, alpha);
+                buf.addVertex(m, cx0, cy1, planeZ).setUv(uMin, vMax).setColor(230, 20, 20, alpha);
+            }
+        }
+    }
+
+    /**
+     * Dedup for coincident same-direction faces. When two boxes have their outward face on the
+     * exact same plane (e.g. both L-bridge segments ending at the same X, or two pieces ending
+     * at the same Y), the per-sample {@link #exteriorHidden} test passes for both — neither
+     * box's exterior sample lies inside the other. Without dedup both render and the texture
+     * doubles up. Rule: render only if {@code ownerIdx} is the lowest-indexed box claiming the
+     * cell.
+     */
+    private static boolean coincidentDuplicateX(List<BoundingBox> all, int ownerIdx, float planeX,
+                                                 float cellMinY, float cellMaxY, float cellMinZ, float cellMaxZ) {
+        for (int i = 0; i < ownerIdx; i++) {
+            BoundingBox b = all.get(i);
+            if (b.maxX() + 1.0f != planeX && (float) b.minX() != planeX) continue;
+            if (cellMaxY > b.minY() && cellMinY < b.maxY() + 1.0f
+                    && cellMaxZ > b.minZ() && cellMinZ < b.maxZ() + 1.0f) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean coincidentDuplicateY(List<BoundingBox> all, int ownerIdx, float planeY,
+                                                 float cellMinX, float cellMaxX, float cellMinZ, float cellMaxZ) {
+        for (int i = 0; i < ownerIdx; i++) {
+            BoundingBox b = all.get(i);
+            if (b.maxY() + 1.0f != planeY && (float) b.minY() != planeY) continue;
+            if (cellMaxX > b.minX() && cellMinX < b.maxX() + 1.0f
+                    && cellMaxZ > b.minZ() && cellMinZ < b.maxZ() + 1.0f) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean coincidentDuplicateZ(List<BoundingBox> all, int ownerIdx, float planeZ,
+                                                 float cellMinX, float cellMaxX, float cellMinY, float cellMaxY) {
+        for (int i = 0; i < ownerIdx; i++) {
+            BoundingBox b = all.get(i);
+            if (b.maxZ() + 1.0f != planeZ && (float) b.minZ() != planeZ) continue;
+            if (cellMaxX > b.minX() && cellMinX < b.maxX() + 1.0f
+                    && cellMaxY > b.minY() && cellMinY < b.maxY() + 1.0f) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * True when a half-block sample on the OUTSIDE of the face lies strictly inside another
+     * shape in the zone — meaning the face is interior to the union and shouldn't be drawn.
+     * Coincident-face cells (sample sits exactly on another box's boundary) survive here and
+     * are handled by the {@code coincidentDuplicate*} dedup instead.
+     */
+    private static boolean exteriorHidden(List<BoundingBox> all, BoundingBox owner,
+                                           double x, double y, double z) {
+        for (BoundingBox b : all) {
+            if (b == owner) continue;
+            if (x > b.minX() && x < b.maxX() + 1.0
+                    && y > b.minY() && y < b.maxY() + 1.0
+                    && z > b.minZ() && z < b.maxZ() + 1.0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static int alphaForDist(double dist, double threshold) {

--- a/src/main/java/net/bananemdnsa/historystages/client/LockOverlayRenderer.java
+++ b/src/main/java/net/bananemdnsa/historystages/client/LockOverlayRenderer.java
@@ -1,0 +1,63 @@
+package net.bananemdnsa.historystages.client;
+
+import net.bananemdnsa.historystages.Config;
+import net.bananemdnsa.historystages.HistoryStages;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RenderGuiEvent;
+
+import java.util.List;
+
+/**
+ * Full-screen red tint drawn over the HUD when the local player's position lies inside any of
+ * the lock shapes cached by {@link LockBorderClientCache}. Looks like the player is wearing
+ * red glasses — a constant signal that they're inside a locked structure.
+ *
+ * <p>Containment is checked client-side against the cached shapes. No extra packet needed:
+ * the same shape list that drives the wall force-field also drives this overlay, so the two
+ * stay in sync automatically.
+ */
+@EventBusSubscriber(modid = HistoryStages.MOD_ID, value = Dist.CLIENT)
+public final class LockOverlayRenderer {
+
+    private LockOverlayRenderer() {}
+
+    @SubscribeEvent
+    public static void onRenderGui(RenderGuiEvent.Post event) {
+        if (!Config.CLIENT.structureLockOverlayEnabled.get()) return;
+
+        Minecraft mc = Minecraft.getInstance();
+        LocalPlayer player = mc.player;
+        if (player == null || player.isSpectator()) return;
+        if (mc.options.hideGui) return;
+
+        if (!isInsideLockedShape(player.getX(), player.getY(), player.getZ())) return;
+
+        double opacity = Config.CLIENT.structureLockOverlayOpacity.get();
+        if (opacity <= 0.0) return;
+
+        int alpha = (int) Math.round(Math.min(1.0, opacity) * 255.0);
+        // ARGB: high alpha + saturated red; GuiGraphics#fill takes 0xAARRGGBB.
+        int color = (alpha << 24) | 0x00C00000;
+
+        GuiGraphics gg = event.getGuiGraphics();
+        gg.fill(0, 0, gg.guiWidth(), gg.guiHeight(), color);
+    }
+
+    private static boolean isInsideLockedShape(double x, double y, double z) {
+        List<BoundingBox> boxes = LockBorderClientCache.get();
+        for (BoundingBox b : boxes) {
+            if (x > b.minX() && x < b.maxX() + 1.0
+                    && y > b.minY() && y < b.maxY() + 1.0
+                    && z > b.minZ() && z < b.maxZ() + 1.0) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/net/bananemdnsa/historystages/client/editor/ConfigEditorScreen.java
+++ b/src/main/java/net/bananemdnsa/historystages/client/editor/ConfigEditorScreen.java
@@ -353,9 +353,6 @@ public class ConfigEditorScreen extends Screen {
         structureLock.add(new ConfigEntry("structureBlockLeftClick", ConfigType.BOOLEAN,
                 Config.COMMON.structureBlockLeftClick.get().toString(), false, "true",
                 "Cancel ALL left-click interactions (attacking entities, breaking blocks) while inside a locked structure?"));
-        structureLock.add(new ConfigEntry("structureWallMode", ConfigType.BOOLEAN,
-                Config.COMMON.structureWallMode.get().toString(), false, "true",
-                "WALL mode: bounce the player back at the boundary. Disable for DAMAGE mode (legacy)."));
         structureLock.add(new ConfigEntry("structureBlockProjectiles", ConfigType.BOOLEAN,
                 Config.COMMON.structureBlockProjectiles.get().toString(), false, "true",
                 "Cancel projectiles (arrows, snowballs, ender pearls, etc.) that would impact inside a locked structure?"));

--- a/src/main/java/net/bananemdnsa/historystages/client/editor/ConfigEditorScreen.java
+++ b/src/main/java/net/bananemdnsa/historystages/client/editor/ConfigEditorScreen.java
@@ -183,6 +183,21 @@ public class ConfigEditorScreen extends Screen {
                 "If mobShowChat is true, should the required stages also be listed?"));
         clientSections.add(mobLock);
 
+        ConfigSection structureVisuals = new ConfigSection("editor.historystages.config.structure_visuals");
+        structureVisuals.add(new ConfigEntry("structureBorderEnabled", ConfigType.BOOLEAN,
+                Config.CLIENT.structureBorderEnabled.get().toString(), true, "true",
+                "Render a force-field-style border on the walls of locked structures when you get close?"));
+        structureVisuals.add(new ConfigEntry("structureBorderDistance", ConfigType.STRING,
+                Config.CLIENT.structureBorderDistance.get().toString(), true, "8.0",
+                "How close (in blocks) to a locked structure wall before the border becomes visible (1.0-32.0)."));
+        structureVisuals.add(new ConfigEntry("structureLockOverlayEnabled", ConfigType.BOOLEAN,
+                Config.CLIENT.structureLockOverlayEnabled.get().toString(), true, "true",
+                "While standing inside a locked structure, tint the whole screen red (red-glasses effect)?"));
+        structureVisuals.add(new ConfigEntry("structureLockOverlayOpacity", ConfigType.STRING,
+                Config.CLIENT.structureLockOverlayOpacity.get().toString(), true, "0.3",
+                "Opacity of the red lock-overlay (0.0 = invisible, 1.0 = fully opaque)."));
+        clientSections.add(structureVisuals);
+
         ConfigSection dependenciesClient = new ConfigSection("editor.historystages.config.dependencies");
         dependenciesClient.add(new ConfigEntry("showDependenciesOnScroll", ConfigType.BOOLEAN,
                 Config.CLIENT.showDependenciesOnScroll.get().toString(), true, "true",
@@ -888,6 +903,14 @@ public class ConfigEditorScreen extends Screen {
                 case "mobShowStagesInChat" -> Config.CLIENT.mobShowStagesInChat.set(Boolean.parseBoolean(value));
                 case "showSilverLockIcons" -> Config.CLIENT.showSilverLockIcons.set(Boolean.parseBoolean(value));
                 case "showIndividualTooltips" -> Config.CLIENT.showIndividualTooltips.set(Boolean.parseBoolean(value));
+                case "structureBorderEnabled" -> Config.CLIENT.structureBorderEnabled.set(Boolean.parseBoolean(value));
+                case "structureBorderDistance" -> {
+                    try { Config.CLIENT.structureBorderDistance.set(Double.parseDouble(value)); } catch (NumberFormatException ignored) {}
+                }
+                case "structureLockOverlayEnabled" -> Config.CLIENT.structureLockOverlayEnabled.set(Boolean.parseBoolean(value));
+                case "structureLockOverlayOpacity" -> {
+                    try { Config.CLIENT.structureLockOverlayOpacity.set(Double.parseDouble(value)); } catch (NumberFormatException ignored) {}
+                }
             }
         }
     }

--- a/src/main/java/net/bananemdnsa/historystages/client/editor/ConfigEditorScreen.java
+++ b/src/main/java/net/bananemdnsa/historystages/client/editor/ConfigEditorScreen.java
@@ -347,6 +347,12 @@ public class ConfigEditorScreen extends Screen {
         structureLock.add(new ConfigEntry("structureDamageInterval", ConfigType.INTEGER,
                 Config.COMMON.structureDamageInterval.get().toString(), false, "20",
                 "How often (in ticks) to deal damage while inside a locked structure."));
+        structureLock.add(new ConfigEntry("structureBlockRightClick", ConfigType.BOOLEAN,
+                Config.COMMON.structureBlockRightClick.get().toString(), false, "true",
+                "Cancel ALL right-click interactions (blocks, items, entities) while inside a locked structure?"));
+        structureLock.add(new ConfigEntry("structureBlockLeftClick", ConfigType.BOOLEAN,
+                Config.COMMON.structureBlockLeftClick.get().toString(), false, "true",
+                "Cancel ALL left-click interactions (attacking entities, breaking blocks) while inside a locked structure?"));
         commonSections.add(structureLock);
 
         ConfigSection lockMessages = new ConfigSection("editor.historystages.config.lock_messages");

--- a/src/main/java/net/bananemdnsa/historystages/client/editor/ConfigEditorScreen.java
+++ b/src/main/java/net/bananemdnsa/historystages/client/editor/ConfigEditorScreen.java
@@ -353,6 +353,12 @@ public class ConfigEditorScreen extends Screen {
         structureLock.add(new ConfigEntry("structureBlockLeftClick", ConfigType.BOOLEAN,
                 Config.COMMON.structureBlockLeftClick.get().toString(), false, "true",
                 "Cancel ALL left-click interactions (attacking entities, breaking blocks) while inside a locked structure?"));
+        structureLock.add(new ConfigEntry("structureWallMode", ConfigType.BOOLEAN,
+                Config.COMMON.structureWallMode.get().toString(), false, "true",
+                "WALL mode: bounce the player back at the boundary. Disable for DAMAGE mode (legacy)."));
+        structureLock.add(new ConfigEntry("structureBlockProjectiles", ConfigType.BOOLEAN,
+                Config.COMMON.structureBlockProjectiles.get().toString(), false, "true",
+                "Cancel projectiles (arrows, snowballs, ender pearls, etc.) that would impact inside a locked structure?"));
         commonSections.add(structureLock);
 
         ConfigSection lockMessages = new ConfigSection("editor.historystages.config.lock_messages");

--- a/src/main/java/net/bananemdnsa/historystages/commands/ClientDebugCommand.java
+++ b/src/main/java/net/bananemdnsa/historystages/commands/ClientDebugCommand.java
@@ -4,7 +4,9 @@ import com.mojang.brigadier.CommandDispatcher;
 import net.bananemdnsa.historystages.HistoryStages;
 import net.bananemdnsa.historystages.client.editor.StageOverviewScreen;
 import net.bananemdnsa.historystages.network.PacketHandler;
+import net.bananemdnsa.historystages.network.RequestClusterShapesPacket;
 import net.bananemdnsa.historystages.network.RequestStructureDebugPacket;
+import net.bananemdnsa.historystages.network.ToggleStructureVizPacket;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.commands.CommandSourceStack;
@@ -53,6 +55,10 @@ public final class ClientDebugCommand {
                                 .executes(ctx -> openEditor(ctx.getSource())))
                         .then(Commands.literal("structure")
                                 .executes(ctx -> requestStructure(ctx.getSource())))
+                        .then(Commands.literal("viz")
+                                .executes(ctx -> toggleViz(ctx.getSource())))
+                        .then(Commands.literal("shapes")
+                                .executes(ctx -> requestShapes(ctx.getSource())))
                         .then(Commands.literal("nbt")
                                 .then(Commands.literal("preset")
                                         .executes(ctx -> handlePreset(ctx.getSource())))
@@ -80,6 +86,24 @@ public final class ClientDebugCommand {
             return 0;
         }
         PacketHandler.sendToServer(new RequestStructureDebugPacket());
+        return 1;
+    }
+
+    private static int toggleViz(CommandSourceStack source) {
+        if (Minecraft.getInstance().player == null) {
+            source.sendFailure(Component.literal("This command can only be run by a player."));
+            return 0;
+        }
+        PacketHandler.sendToServer(new ToggleStructureVizPacket());
+        return 1;
+    }
+
+    private static int requestShapes(CommandSourceStack source) {
+        if (Minecraft.getInstance().player == null) {
+            source.sendFailure(Component.literal("This command can only be run by a player."));
+            return 0;
+        }
+        PacketHandler.sendToServer(new RequestClusterShapesPacket());
         return 1;
     }
 

--- a/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
@@ -4,26 +4,23 @@ import net.bananemdnsa.historystages.Config;
 import net.bananemdnsa.historystages.HistoryStages;
 import net.bananemdnsa.historystages.data.StageEntry;
 import net.bananemdnsa.historystages.data.StageManager;
+import net.bananemdnsa.historystages.structure.ClusterBuilder;
+import net.bananemdnsa.historystages.structure.ClusterDebugRenderer;
+import net.bananemdnsa.historystages.structure.StructureCluster;
 import net.bananemdnsa.historystages.util.DebugLogger;
 import net.bananemdnsa.historystages.util.IndividualStageData;
 import net.bananemdnsa.historystages.util.StageData;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SpawnerBlock;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.levelgen.structure.Structure;
-import net.minecraft.world.level.levelgen.structure.StructureStart;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
@@ -53,6 +50,10 @@ public class StructureLockHandler {
         int messageCooldown = 0;
         List<String> cachedLockedStructureIds = Collections.emptyList();
         List<String> cachedLockedStageIds = Collections.emptyList();
+        /** Clusters near the player belonging to any locked structure (regardless of stage gating). */
+        List<StructureCluster> cachedNearbyClusters = Collections.emptyList();
+        /** Subset of nearby clusters whose structure is currently locked AND which contain the player. */
+        List<StructureCluster> cachedActiveLockedClusters = Collections.emptyList();
     }
 
     @SubscribeEvent
@@ -72,8 +73,10 @@ public class StructureLockHandler {
         if (chunkChanged || state.checkCooldown <= 0) {
             state.checkCooldown = interval;
             state.lastChunkKey = chunkKey;
-            recomputeLockedStructures(player, state);
+            recompute(player, state);
         }
+
+        ClusterDebugRenderer.tick(player, state.cachedNearbyClusters, state.cachedActiveLockedClusters);
 
         if (state.cachedLockedStructureIds.isEmpty()) return;
 
@@ -95,23 +98,42 @@ public class StructureLockHandler {
         }
     }
 
-    private static void recomputeLockedStructures(ServerPlayer player, PlayerState state) {
+    private static void recompute(ServerPlayer player, PlayerState state) {
         ServerLevel level = player.serverLevel();
         BlockPos pos = player.blockPosition();
 
-        List<Holder.Reference<Structure>> holders = collectStructureHoldersAt(level, pos);
-        if (holders.isEmpty()) {
+        int padding = Config.COMMON.structureLockPadding.get();
+        int clusterDistance = Config.COMMON.structureClusterDistance.get();
+
+        List<StructureCluster> nearby = ClusterBuilder.collectClustersNear(
+                level, pos, CHUNK_SCAN_RADIUS, padding, clusterDistance);
+
+        state.cachedNearbyClusters = nearby;
+
+        if (nearby.isEmpty()) {
             state.cachedLockedStructureIds = Collections.emptyList();
             state.cachedLockedStageIds = Collections.emptyList();
+            state.cachedActiveLockedClusters = Collections.emptyList();
             return;
         }
 
-        // Build present IDs + tags for fast lookup against stage entries
+        // Determine which clusters actually contain the player.
+        List<StructureCluster> active = new ArrayList<>();
         Set<String> presentIds = new HashSet<>();
         Set<String> presentTags = new HashSet<>();
-        for (Holder.Reference<Structure> h : holders) {
+        for (StructureCluster c : nearby) {
+            if (!c.contains(pos)) continue;
+            active.add(c);
+            Holder.Reference<Structure> h = c.structure();
             h.unwrapKey().ifPresent(k -> presentIds.add(k.location().toString()));
             h.tags().forEach(t -> presentTags.add(t.location().toString()));
+        }
+
+        if (active.isEmpty()) {
+            state.cachedLockedStructureIds = Collections.emptyList();
+            state.cachedLockedStageIds = Collections.emptyList();
+            state.cachedActiveLockedClusters = Collections.emptyList();
+            return;
         }
 
         Set<String> playerStages = IndividualStageData.SERVER_CACHE.getOrDefault(
@@ -123,7 +145,7 @@ public class StructureLockHandler {
         // Global stages
         for (Map.Entry<String, StageEntry> e : StageManager.getStages().entrySet()) {
             String stageId = e.getKey();
-            if (StageData.SERVER_CACHE.contains(stageId)) continue; // already unlocked
+            if (StageData.SERVER_CACHE.contains(stageId)) continue;
             List<String> entries = e.getValue().getStructures();
             if (entries == null || entries.isEmpty()) continue;
             for (String entry : entries) {
@@ -135,7 +157,7 @@ public class StructureLockHandler {
             }
         }
 
-        // Individual stages (per-player)
+        // Individual stages
         for (Map.Entry<String, StageEntry> e : StageManager.getIndividualStages().entrySet()) {
             String stageId = e.getKey();
             if (playerStages.contains(stageId)) continue;
@@ -152,13 +174,23 @@ public class StructureLockHandler {
 
         state.cachedLockedStructureIds = new ArrayList<>(lockedStructures);
         state.cachedLockedStageIds = new ArrayList<>(lockedStages);
+
+        // Active locked clusters = active clusters whose structure id matches one of the locked ids.
+        List<StructureCluster> activeLocked = new ArrayList<>();
+        for (StructureCluster c : active) {
+            String id = c.structure().unwrapKey().map(k -> k.location().toString()).orElse(null);
+            if (id == null) continue;
+            if (lockedStructures.contains(id)) {
+                activeLocked.add(c);
+                continue;
+            }
+            // Match via tags too (entries starting with #)
+            boolean tagMatched = c.structure().tags().anyMatch(t -> lockedStructures.contains("#" + t.location()));
+            if (tagMatched) activeLocked.add(c);
+        }
+        state.cachedActiveLockedClusters = activeLocked;
     }
 
-    /**
-     * Checks whether a stage entry (either "minecraft:village" or "#minecraft:village")
-     * matches the player's current structure context. Returns the matching structure ID
-     * label or null if no match.
-     */
     private static String matchEntry(String entry, Set<String> presentIds, Set<String> presentTags) {
         if (entry == null || entry.isEmpty()) return null;
         if (entry.startsWith("#")) {
@@ -169,8 +201,9 @@ public class StructureLockHandler {
     }
 
     /**
-     * Returns ResourceLocation IDs of all structures containing the given position.
-     * Used by the debug command and other callers that only need IDs.
+     * Returns ResourceLocation IDs of all structures whose start BB contains pos.
+     * Kept for compatibility with {@code /history debug structure} which lists every
+     * structure the player is currently inside, independent of the active lock mode.
      */
     public static List<String> collectStructureIdsAt(ServerLevel level, BlockPos pos) {
         List<Holder.Reference<Structure>> holders = collectStructureHoldersAt(level, pos);
@@ -183,46 +216,32 @@ public class StructureLockHandler {
     }
 
     /**
-     * Returns Holder.Reference for every structure whose bounding box contains pos.
-     * Uses two strategies and merges results:
-     * 1. Vanilla {@code StructureManager.getAllStructuresAt} (cross-chunk references).
-     * 2. Manual scan of loaded chunks in a radius — catches structures at the edge of loading.
+     * Lists structures whose vanilla start bounding box contains {@code pos}. Used by the
+     * structure debug command — intentionally independent of the cluster-based lock logic
+     * so admins always see every structure that geometrically overlaps the position.
      */
     public static List<Holder.Reference<Structure>> collectStructureHoldersAt(ServerLevel level, BlockPos pos) {
-        Registry<Structure> registry = level.registryAccess().registryOrThrow(Registries.STRUCTURE);
-
-        Set<Structure> found = new LinkedHashSet<>();
-
-        // Strategy 1: vanilla lookup
-        try {
-            Map<Structure, ?> all = level.structureManager().getAllStructuresAt(pos);
-            found.addAll(all.keySet());
-        } catch (Throwable t) {
-            // Some chunks may not have structure references populated — fall through
-        }
-
-        // Strategy 2: scan loaded chunks in a radius and match bounding boxes directly
-        ChunkPos center = new ChunkPos(pos);
+        var registry = level.registryAccess().registryOrThrow(net.minecraft.core.registries.Registries.STRUCTURE);
+        net.minecraft.world.level.ChunkPos center = new net.minecraft.world.level.ChunkPos(pos);
+        Set<Structure> seen = new LinkedHashSet<>();
         for (int cx = center.x - CHUNK_SCAN_RADIUS; cx <= center.x + CHUNK_SCAN_RADIUS; cx++) {
             for (int cz = center.z - CHUNK_SCAN_RADIUS; cz <= center.z + CHUNK_SCAN_RADIUS; cz++) {
-                ChunkAccess chunk = level.getChunkSource().getChunkNow(cx, cz);
+                var chunk = level.getChunkSource().getChunkNow(cx, cz);
                 if (chunk == null) continue;
-                for (Map.Entry<Structure, StructureStart> e : chunk.getAllStarts().entrySet()) {
-                    StructureStart start = e.getValue();
+                for (var entry : chunk.getAllStarts().entrySet()) {
+                    var start = entry.getValue();
                     if (start == null || !start.isValid()) continue;
                     if (!start.getBoundingBox().isInside(pos)) continue;
-                    found.add(e.getKey());
+                    seen.add(entry.getKey());
                 }
             }
         }
-
-        if (found.isEmpty()) return Collections.emptyList();
-
-        List<Holder.Reference<Structure>> out = new ArrayList<>(found.size());
-        for (Structure s : found) {
-            ResourceLocation key = registry.getKey(s);
+        if (seen.isEmpty()) return Collections.emptyList();
+        List<Holder.Reference<Structure>> out = new ArrayList<>(seen.size());
+        for (Structure s : seen) {
+            var key = registry.getKey(s);
             if (key == null) continue;
-            registry.getHolder(net.minecraft.resources.ResourceKey.create(Registries.STRUCTURE, key))
+            registry.getHolder(net.minecraft.resources.ResourceKey.create(net.minecraft.core.registries.Registries.STRUCTURE, key))
                     .ifPresent(out::add);
         }
         return out;
@@ -238,7 +257,7 @@ public class StructureLockHandler {
         String formatted = format
                 .replace("{structure}", structureId)
                 .replace("{stage}", stageName)
-                .replace('&', '\u00A7');
+                .replace('&', '§');
 
         Component msg = Component.literal(formatted);
 
@@ -258,10 +277,6 @@ public class StructureLockHandler {
         return entry != null ? entry.getDisplayName() : stageId;
     }
 
-    /**
-     * Checks if the player is currently inside any locked structure
-     * (used by interaction blockers).
-     */
     public static boolean isInsideLockedStructure(Player player) {
         PlayerState state = STATE.get(player.getUUID());
         return state != null && !state.cachedLockedStructureIds.isEmpty();
@@ -271,10 +286,6 @@ public class StructureLockHandler {
         STATE.remove(uuid);
     }
 
-    /**
-     * Blocks interaction with containers and spawners while the player
-     * is inside a locked structure.
-     */
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
         if (event.getEntity().level().isClientSide()) return;

--- a/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
@@ -18,7 +18,9 @@ import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
+import net.neoforged.neoforge.common.util.TriState;
 import net.minecraft.world.level.levelgen.structure.Structure;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -28,6 +30,7 @@ import net.neoforged.neoforge.event.entity.player.AttackEntityEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
 import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.ExplosionEvent;
 import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 
 import java.util.ArrayList;
@@ -405,22 +408,44 @@ public class StructureLockHandler {
      */
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (shouldBlockInteraction(event.getEntity(), true, false, event.getPos())) event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), true, false, event.getPos())) {
+            cancelBlockClick(event);
+            return;
+        }
+        // Also catch placements where the CLICKED block is outside the zone but the resulting
+        // placement target is inside: water/lava buckets, TNT, block placement against the
+        // boundary wall. Without this a player could flood a locked village from the outside.
+        BlockPos placePos = event.getPos().relative(event.getFace());
+        if (shouldBlockInteraction(event.getEntity(), true, false, placePos)) {
+            cancelBlockClick(event);
+        }
     }
 
     @SubscribeEvent
     public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
-        if (shouldBlockInteraction(event.getEntity(), true, false, null)) event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), true, false, null)) {
+            event.setCanceled(true);
+            event.setCancellationResult(InteractionResult.FAIL);
+            forceInventoryResync(event.getEntity());
+        }
     }
 
     @SubscribeEvent
     public static void onEntityInteract(PlayerInteractEvent.EntityInteract event) {
-        if (shouldBlockInteraction(event.getEntity(), true, false, event.getTarget().blockPosition())) event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), true, false, event.getTarget().blockPosition())) {
+            event.setCanceled(true);
+            event.setCancellationResult(InteractionResult.FAIL);
+            forceInventoryResync(event.getEntity());
+        }
     }
 
     @SubscribeEvent
     public static void onEntityInteractSpecific(PlayerInteractEvent.EntityInteractSpecific event) {
-        if (shouldBlockInteraction(event.getEntity(), true, false, event.getTarget().blockPosition())) event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), true, false, event.getTarget().blockPosition())) {
+            event.setCanceled(true);
+            event.setCancellationResult(InteractionResult.FAIL);
+            forceInventoryResync(event.getEntity());
+        }
     }
 
     /**
@@ -430,7 +455,41 @@ public class StructureLockHandler {
      */
     @SubscribeEvent
     public static void onLeftClickBlock(PlayerInteractEvent.LeftClickBlock event) {
-        if (shouldBlockInteraction(event.getEntity(), false, true, event.getPos())) event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), false, true, event.getPos())) {
+            cancelBlockClick(event);
+        }
+    }
+
+    /**
+     * Cancellation for both RightClickBlock and LeftClickBlock. The combination
+     * {@code setUseItem(FALSE) + setUseBlock(FALSE) + setCanceled(true) + setCancellationResult(FAIL)}
+     * tells the server-side logic the action did not happen. But the client already locally
+     * predicted the placement / item consumption, and the FAIL result doesn't always trigger
+     * a re-sync — so we also push the full inventory state back to the client to undo the
+     * prediction. Without the {@link #forceInventoryResync} call the placed block / emptied
+     * bucket would stay missing from the player's hand even though the world wasn't changed.
+     */
+    private static void cancelBlockClick(PlayerInteractEvent.RightClickBlock event) {
+        event.setUseBlock(TriState.FALSE);
+        event.setUseItem(TriState.FALSE);
+        event.setCanceled(true);
+        event.setCancellationResult(InteractionResult.FAIL);
+        forceInventoryResync(event.getEntity());
+    }
+
+    private static void cancelBlockClick(PlayerInteractEvent.LeftClickBlock event) {
+        // LeftClickBlock has no setCancellationResult — block-break doesn't return a result
+        // that needs client-side sync. The TriState calls plus setCanceled are enough; no
+        // inventory resync needed because left-click doesn't consume items.
+        event.setUseBlock(TriState.FALSE);
+        event.setUseItem(TriState.FALSE);
+        event.setCanceled(true);
+    }
+
+    private static void forceInventoryResync(Player player) {
+        if (player instanceof ServerPlayer sp) {
+            sp.containerMenu.broadcastFullState();
+        }
     }
 
     @SubscribeEvent
@@ -483,6 +542,30 @@ public class StructureLockHandler {
 
         event.setCanceled(true);
         event.getProjectile().discard();
+    }
+
+    /**
+     * Filters explosion affected-blocks: any block that lies inside any online player's cached
+     * locked zone is removed from the list, so the explosion can't damage protected structure
+     * blocks. TNT, creeper, end-crystal, bed-in-nether — all explosion types route through
+     * this event. We scan every player's cache because explosions have no clean "owner" to
+     * attribute the source to (and even if they did, the zones nearby ANY player matter).
+     */
+    @SubscribeEvent
+    public static void onExplosionDetonate(ExplosionEvent.Detonate event) {
+        if (event.getLevel().isClientSide()) return;
+        if (STATE.isEmpty()) return;
+        List<BlockPos> affected = event.getAffectedBlocks();
+        if (affected.isEmpty()) return;
+
+        affected.removeIf(pos -> {
+            for (PlayerState s : STATE.values()) {
+                for (StructureCluster c : s.cachedLockedNearby) {
+                    if (c.contains(pos)) return true;
+                }
+            }
+            return false;
+        });
     }
 
     @SubscribeEvent

--- a/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
@@ -4,9 +4,12 @@ import net.bananemdnsa.historystages.Config;
 import net.bananemdnsa.historystages.HistoryStages;
 import net.bananemdnsa.historystages.data.StageEntry;
 import net.bananemdnsa.historystages.data.StageManager;
+import net.bananemdnsa.historystages.network.PacketHandler;
+import net.bananemdnsa.historystages.network.SyncLockBordersPacket;
 import net.bananemdnsa.historystages.structure.ClusterBuilder;
 import net.bananemdnsa.historystages.structure.ClusterDebugRenderer;
 import net.bananemdnsa.historystages.structure.StructureCluster;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.bananemdnsa.historystages.util.DebugLogger;
 import net.bananemdnsa.historystages.util.IndividualStageData;
 import net.bananemdnsa.historystages.util.StageData;
@@ -54,6 +57,8 @@ public class StructureLockHandler {
         List<StructureCluster> cachedNearbyClusters = Collections.emptyList();
         /** Subset of nearby clusters whose structure is currently locked AND which contain the player. */
         List<StructureCluster> cachedActiveLockedClusters = Collections.emptyList();
+        /** Hash of the last-sent border BB list, to skip redundant network sends. */
+        int lastBorderHash = 0;
     }
 
     @SubscribeEvent
@@ -114,26 +119,18 @@ public class StructureLockHandler {
             state.cachedLockedStructureIds = Collections.emptyList();
             state.cachedLockedStageIds = Collections.emptyList();
             state.cachedActiveLockedClusters = Collections.emptyList();
+            syncBordersIfChanged(player, state, Collections.emptyList());
             return;
         }
 
-        // Determine which clusters actually contain the player.
-        List<StructureCluster> active = new ArrayList<>();
+        // Collect structure IDs/tags from ALL nearby clusters so we can match locked
+        // entries even when the player is just close to (not inside) a structure.
         Set<String> presentIds = new HashSet<>();
         Set<String> presentTags = new HashSet<>();
         for (StructureCluster c : nearby) {
-            if (!c.contains(pos)) continue;
-            active.add(c);
             Holder.Reference<Structure> h = c.structure();
             h.unwrapKey().ifPresent(k -> presentIds.add(k.location().toString()));
             h.tags().forEach(t -> presentTags.add(t.location().toString()));
-        }
-
-        if (active.isEmpty()) {
-            state.cachedLockedStructureIds = Collections.emptyList();
-            state.cachedLockedStageIds = Collections.emptyList();
-            state.cachedActiveLockedClusters = Collections.emptyList();
-            return;
         }
 
         Set<String> playerStages = IndividualStageData.SERVER_CACHE.getOrDefault(
@@ -142,7 +139,6 @@ public class StructureLockHandler {
         LinkedHashSet<String> lockedStructures = new LinkedHashSet<>();
         LinkedHashSet<String> lockedStages = new LinkedHashSet<>();
 
-        // Global stages
         for (Map.Entry<String, StageEntry> e : StageManager.getStages().entrySet()) {
             String stageId = e.getKey();
             if (StageData.SERVER_CACHE.contains(stageId)) continue;
@@ -157,7 +153,6 @@ public class StructureLockHandler {
             }
         }
 
-        // Individual stages
         for (Map.Entry<String, StageEntry> e : StageManager.getIndividualStages().entrySet()) {
             String stageId = e.getKey();
             if (playerStages.contains(stageId)) continue;
@@ -172,23 +167,90 @@ public class StructureLockHandler {
             }
         }
 
-        state.cachedLockedStructureIds = new ArrayList<>(lockedStructures);
-        state.cachedLockedStageIds = new ArrayList<>(lockedStages);
-
-        // Active locked clusters = active clusters whose structure id matches one of the locked ids.
+        // Locked clusters near the player (regardless of whether they contain him).
+        // Border rendering uses this; the "active" subset (containing pos) drives the
+        // damage / message paths.
+        List<StructureCluster> lockedNearby = new ArrayList<>();
         List<StructureCluster> activeLocked = new ArrayList<>();
-        for (StructureCluster c : active) {
-            String id = c.structure().unwrapKey().map(k -> k.location().toString()).orElse(null);
-            if (id == null) continue;
-            if (lockedStructures.contains(id)) {
+        LinkedHashSet<String> activeStructureIds = new LinkedHashSet<>();
+        LinkedHashSet<String> activeStageIds = new LinkedHashSet<>();
+
+        for (StructureCluster c : nearby) {
+            if (!structureMatchesLocked(c, lockedStructures)) continue;
+            lockedNearby.add(c);
+            if (c.contains(pos)) {
                 activeLocked.add(c);
-                continue;
+                c.structure().unwrapKey().ifPresent(k -> activeStructureIds.add(k.location().toString()));
             }
-            // Match via tags too (entries starting with #)
-            boolean tagMatched = c.structure().tags().anyMatch(t -> lockedStructures.contains("#" + t.location()));
-            if (tagMatched) activeLocked.add(c);
         }
+
+        // Stage IDs whose entries actually intersect an active (contained) cluster.
+        if (!activeLocked.isEmpty()) {
+            Set<String> activeIdsView = activeStructureIds;
+            Set<String> activeTagsView = new HashSet<>();
+            for (StructureCluster c : activeLocked) {
+                c.structure().tags().forEach(t -> activeTagsView.add(t.location().toString()));
+            }
+            for (Map.Entry<String, StageEntry> e : StageManager.getStages().entrySet()) {
+                if (!lockedStages.contains(e.getKey())) continue;
+                List<String> entries = e.getValue().getStructures();
+                if (entries == null) continue;
+                for (String entry : entries) {
+                    if (matchEntry(entry, activeIdsView, activeTagsView) != null) {
+                        activeStageIds.add(e.getKey());
+                        break;
+                    }
+                }
+            }
+            for (Map.Entry<String, StageEntry> e : StageManager.getIndividualStages().entrySet()) {
+                if (!lockedStages.contains(e.getKey())) continue;
+                List<String> entries = e.getValue().getStructures();
+                if (entries == null) continue;
+                for (String entry : entries) {
+                    if (matchEntry(entry, activeIdsView, activeTagsView) != null) {
+                        activeStageIds.add(e.getKey());
+                        break;
+                    }
+                }
+            }
+        }
+
+        state.cachedLockedStructureIds = new ArrayList<>(activeStructureIds);
+        state.cachedLockedStageIds = new ArrayList<>(activeStageIds);
         state.cachedActiveLockedClusters = activeLocked;
+
+        // For border rendering we send one envelope per locked cluster — the union of all
+        // its lockShapes — so the client sees a single outer wall per village/dungeon
+        // instead of many small box faces.
+        List<BoundingBox> borderShapes = new ArrayList<>(lockedNearby.size());
+        for (StructureCluster c : lockedNearby) borderShapes.add(c.bounds());
+        syncBordersIfChanged(player, state, borderShapes);
+    }
+
+    private static boolean structureMatchesLocked(StructureCluster c, Set<String> lockedStructures) {
+        String id = c.structure().unwrapKey().map(k -> k.location().toString()).orElse(null);
+        if (id != null && lockedStructures.contains(id)) return true;
+        return c.structure().tags().anyMatch(t -> lockedStructures.contains("#" + t.location()));
+    }
+
+    private static void syncBordersIfChanged(ServerPlayer player, PlayerState state, List<BoundingBox> shapes) {
+        int hash = computeBoxHash(shapes);
+        if (hash == state.lastBorderHash) return;
+        state.lastBorderHash = hash;
+        PacketHandler.sendLockBordersToPlayer(new SyncLockBordersPacket(shapes), player);
+    }
+
+    private static int computeBoxHash(List<BoundingBox> shapes) {
+        int h = shapes.size();
+        for (BoundingBox b : shapes) {
+            h = h * 31 + b.minX();
+            h = h * 31 + b.minY();
+            h = h * 31 + b.minZ();
+            h = h * 31 + b.maxX();
+            h = h * 31 + b.maxY();
+            h = h * 31 + b.maxZ();
+        }
+        return h;
     }
 
     private static String matchEntry(String entry, Set<String> presentIds, Set<String> presentTags) {

--- a/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
@@ -64,10 +64,6 @@ public class StructureLockHandler {
         List<StructureCluster> cachedActiveLockedClusters = Collections.emptyList();
         /** Hash of the last-sent border BB list, to skip redundant network sends. */
         int lastBorderHash = 0;
-        /** Last known outside-the-zone position (for wall-mode bounce-back). Null until first tick. */
-        Vec3 lastSafePos = null;
-        /** Whether the player was inside a locked zone on the previous tick (for wall-mode transition detection). */
-        boolean lastTickInside = false;
     }
 
     @SubscribeEvent
@@ -82,13 +78,6 @@ public class StructureLockHandler {
         int interval = Config.COMMON.structureCheckInterval.get();
         long chunkKey = (((long) player.chunkPosition().x) << 32) | (player.chunkPosition().z & 0xFFFFFFFFL);
         boolean chunkChanged = chunkKey != state.lastChunkKey;
-
-        // Wall-mode bounce runs BEFORE recompute so the player is teleported out before any
-        // damage/message handlers see them as "inside". Uses the previous tick's cached zones —
-        // safe because zones change only via recompute (chunk-change or interval).
-        if (Config.COMMON.structureWallMode.get()) {
-            applyWallMode(player, state);
-        }
 
         state.checkCooldown--;
         if (chunkChanged || state.checkCooldown <= 0) {
@@ -252,36 +241,6 @@ public class StructureLockHandler {
     private static void fastContainmentUpdate(ServerPlayer player, PlayerState state) {
         if (state.cachedLockedNearby.isEmpty()) return;
         applyContainment(player.blockPosition(), state);
-    }
-
-    /**
-     * Wall-mode enforcement: bounces the player back to the last safe outside position when
-     * they cross a zone boundary INWARDS. Inside→outside and inside→inside moves are allowed
-     * so a player who was already trapped (logged out inside, then admin locked the stage)
-     * can still move around and escape; only fresh entry from outside is blocked.
-     */
-    private static void applyWallMode(ServerPlayer player, PlayerState state) {
-        Vec3 currentPos = player.position();
-        boolean insideNow = isPosInsideAnyLock(player.blockPosition(), state);
-
-        if (state.lastSafePos == null) {
-            // First-tick init: don't bounce regardless of where we are.
-            if (!insideNow) state.lastSafePos = currentPos;
-            state.lastTickInside = insideNow;
-            return;
-        }
-
-        if (insideNow && !state.lastTickInside) {
-            // Crossed from outside to inside this tick. Teleport back to the saved safe spot.
-            player.teleportTo(state.lastSafePos.x, state.lastSafePos.y, state.lastSafePos.z);
-            // Don't update lastSafePos / lastTickInside — after teleport the player is back outside.
-            return;
-        }
-
-        if (!insideNow) {
-            state.lastSafePos = currentPos;
-        }
-        state.lastTickInside = insideNow;
     }
 
     private static boolean isPosInsideAnyLock(BlockPos pos, PlayerState state) {

--- a/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
@@ -22,7 +22,10 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.levelgen.structure.Structure;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.player.AttackEntityEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+import net.neoforged.neoforge.event.level.BlockEvent;
 import net.neoforged.neoforge.event.tick.PlayerTickEvent;
 
 import java.util.ArrayList;
@@ -51,7 +54,11 @@ public class StructureLockHandler {
         List<String> cachedLockedStageIds = Collections.emptyList();
         /** Clusters near the player belonging to any locked structure (regardless of stage gating). */
         List<StructureCluster> cachedNearbyClusters = Collections.emptyList();
-        /** Subset of nearby clusters whose structure is currently locked AND which contain the player. */
+        /** Nearby clusters whose structure is actually locked — input set for the per-tick fast containment check. */
+        List<StructureCluster> cachedLockedNearby = Collections.emptyList();
+        /** Per-cluster mapping of which stage IDs that cluster contributes to (filled by recompute, read by fast update). */
+        Map<StructureCluster, Set<String>> cachedClusterStages = Collections.emptyMap();
+        /** Subset of locked-nearby clusters that contain the player right now. */
         List<StructureCluster> cachedActiveLockedClusters = Collections.emptyList();
         /** Hash of the last-sent border BB list, to skip redundant network sends. */
         int lastBorderHash = 0;
@@ -75,6 +82,11 @@ public class StructureLockHandler {
             state.checkCooldown = interval;
             state.lastChunkKey = chunkKey;
             recompute(player, state);
+        } else {
+            // Cheap per-tick containment recheck so the lock state reacts within one tick
+            // when the player crosses a zone boundary inside an already-scanned area, instead
+            // of waiting up to checkInterval ticks for the next full recompute.
+            fastContainmentUpdate(player, state);
         }
 
         ClusterDebugRenderer.tick(player, state.cachedNearbyClusters, state.cachedActiveLockedClusters);
@@ -115,6 +127,8 @@ public class StructureLockHandler {
             state.cachedLockedStructureIds = Collections.emptyList();
             state.cachedLockedStageIds = Collections.emptyList();
             state.cachedActiveLockedClusters = Collections.emptyList();
+            state.cachedLockedNearby = Collections.emptyList();
+            state.cachedClusterStages = Collections.emptyMap();
             syncBordersIfChanged(player, state, Collections.emptyList());
             return;
         }
@@ -163,37 +177,28 @@ public class StructureLockHandler {
             }
         }
 
-        // Locked clusters near the player (regardless of whether they contain him).
-        // Border rendering uses this; the "active" subset (containing pos) drives the
-        // damage / message paths.
+        // Locked clusters near the player + their per-cluster stage contribution. We compute
+        // (cluster -> stages) here once and cache it so the per-tick fast containment update
+        // can derive activeStageIds without re-iterating every stage entry.
         List<StructureCluster> lockedNearby = new ArrayList<>();
-        List<StructureCluster> activeLocked = new ArrayList<>();
-        LinkedHashSet<String> activeStructureIds = new LinkedHashSet<>();
-        LinkedHashSet<String> activeStageIds = new LinkedHashSet<>();
-
+        Map<StructureCluster, Set<String>> clusterStages = new HashMap<>();
         for (StructureCluster c : nearby) {
             if (!structureMatchesLocked(c, lockedStructures)) continue;
             lockedNearby.add(c);
-            if (c.contains(pos)) {
-                activeLocked.add(c);
-                c.structure().unwrapKey().ifPresent(k -> activeStructureIds.add(k.location().toString()));
-            }
-        }
 
-        // Stage IDs whose entries actually intersect an active (contained) cluster.
-        if (!activeLocked.isEmpty()) {
-            Set<String> activeIdsView = activeStructureIds;
-            Set<String> activeTagsView = new HashSet<>();
-            for (StructureCluster c : activeLocked) {
-                c.structure().tags().forEach(t -> activeTagsView.add(t.location().toString()));
-            }
+            Set<String> idView = new HashSet<>();
+            c.structure().unwrapKey().ifPresent(k -> idView.add(k.location().toString()));
+            Set<String> tagView = new HashSet<>();
+            c.structure().tags().forEach(t -> tagView.add(t.location().toString()));
+
+            Set<String> stages = new LinkedHashSet<>();
             for (Map.Entry<String, StageEntry> e : StageManager.getStages().entrySet()) {
                 if (!lockedStages.contains(e.getKey())) continue;
                 List<String> entries = e.getValue().getStructures();
                 if (entries == null) continue;
                 for (String entry : entries) {
-                    if (matchEntry(entry, activeIdsView, activeTagsView) != null) {
-                        activeStageIds.add(e.getKey());
+                    if (matchEntry(entry, idView, tagView) != null) {
+                        stages.add(e.getKey());
                         break;
                     }
                 }
@@ -203,17 +208,20 @@ public class StructureLockHandler {
                 List<String> entries = e.getValue().getStructures();
                 if (entries == null) continue;
                 for (String entry : entries) {
-                    if (matchEntry(entry, activeIdsView, activeTagsView) != null) {
-                        activeStageIds.add(e.getKey());
+                    if (matchEntry(entry, idView, tagView) != null) {
+                        stages.add(e.getKey());
                         break;
                     }
                 }
             }
+            clusterStages.put(c, stages);
         }
 
-        state.cachedLockedStructureIds = new ArrayList<>(activeStructureIds);
-        state.cachedLockedStageIds = new ArrayList<>(activeStageIds);
-        state.cachedActiveLockedClusters = activeLocked;
+        state.cachedLockedNearby = lockedNearby;
+        state.cachedClusterStages = clusterStages;
+
+        // Derive the active (containing) subset + per-cluster stage IDs.
+        applyContainment(player.blockPosition(), state);
 
         // Send the full lockShape geometry to the client. The renderer culls interior faces
         // (where a shape's face is occluded by another shape) so the force-field texture
@@ -221,6 +229,32 @@ public class StructureLockHandler {
         List<BoundingBox> borderShapes = new ArrayList<>();
         for (StructureCluster c : lockedNearby) borderShapes.addAll(c.lockShapes());
         syncBordersIfChanged(player, state, borderShapes);
+    }
+
+    /**
+     * Per-tick recheck of which locked-nearby clusters contain the player, using the cached
+     * cluster list and the per-cluster stage mapping built by {@link #recompute}. No structure
+     * scan, no stage-entry iteration — just one {@code contains(pos)} per locked cluster.
+     */
+    private static void fastContainmentUpdate(ServerPlayer player, PlayerState state) {
+        if (state.cachedLockedNearby.isEmpty()) return;
+        applyContainment(player.blockPosition(), state);
+    }
+
+    private static void applyContainment(BlockPos pos, PlayerState state) {
+        List<StructureCluster> active = new ArrayList<>();
+        LinkedHashSet<String> activeStructureIds = new LinkedHashSet<>();
+        LinkedHashSet<String> activeStageIds = new LinkedHashSet<>();
+        for (StructureCluster c : state.cachedLockedNearby) {
+            if (!c.contains(pos)) continue;
+            active.add(c);
+            c.structure().unwrapKey().ifPresent(k -> activeStructureIds.add(k.location().toString()));
+            Set<String> stages = state.cachedClusterStages.get(c);
+            if (stages != null) activeStageIds.addAll(stages);
+        }
+        state.cachedActiveLockedClusters = active;
+        state.cachedLockedStructureIds = new ArrayList<>(activeStructureIds);
+        state.cachedLockedStageIds = new ArrayList<>(activeStageIds);
     }
 
     private static boolean structureMatchesLocked(StructureCluster c, Set<String> lockedStructures) {
@@ -346,43 +380,68 @@ public class StructureLockHandler {
 
     /**
      * Blanket-cancels every right-click interaction while the player is inside a locked
-     * structure: blocks (GUIs, doors, redstone, place-on-block), item self-use (eating,
-     * throwing pearls, drawing bows), and entity interactions (villager trading, mounting,
-     * item-frame insertion). The lock zone behaves like a no-touch museum case.
+     * structure (blocks, item self-use, entity interactions). Gated by
+     * {@code structureBlockRightClick}.
      */
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (event.getEntity().level().isClientSide()) return;
-        if (!(event.getEntity() instanceof ServerPlayer player)) return;
-        if (player.isSpectator()) return;
-        if (!isInsideLockedStructure(player)) return;
-        event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), true, false)) event.setCanceled(true);
     }
 
     @SubscribeEvent
     public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
-        if (event.getEntity().level().isClientSide()) return;
-        if (!(event.getEntity() instanceof ServerPlayer player)) return;
-        if (player.isSpectator()) return;
-        if (!isInsideLockedStructure(player)) return;
-        event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), true, false)) event.setCanceled(true);
     }
 
     @SubscribeEvent
     public static void onEntityInteract(PlayerInteractEvent.EntityInteract event) {
-        if (event.getEntity().level().isClientSide()) return;
-        if (!(event.getEntity() instanceof ServerPlayer player)) return;
-        if (player.isSpectator()) return;
-        if (!isInsideLockedStructure(player)) return;
-        event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), true, false)) event.setCanceled(true);
     }
 
     @SubscribeEvent
     public static void onEntityInteractSpecific(PlayerInteractEvent.EntityInteractSpecific event) {
-        if (event.getEntity().level().isClientSide()) return;
-        if (!(event.getEntity() instanceof ServerPlayer player)) return;
-        if (player.isSpectator()) return;
-        if (!isInsideLockedStructure(player)) return;
-        event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), true, false)) event.setCanceled(true);
+    }
+
+    /**
+     * Blanket-cancels every left-click interaction while the player is inside a locked
+     * structure (attacking entities, starting/continuing block-break). Gated by
+     * {@code structureBlockLeftClick}.
+     */
+    @SubscribeEvent
+    public static void onLeftClickBlock(PlayerInteractEvent.LeftClickBlock event) {
+        if (shouldBlockInteraction(event.getEntity(), false, true)) event.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public static void onAttackEntity(AttackEntityEvent event) {
+        if (shouldBlockInteraction(event.getEntity(), false, true)) event.setCanceled(true);
+    }
+
+    @SubscribeEvent
+    public static void onBlockBreak(BlockEvent.BreakEvent event) {
+        if (shouldBlockInteraction(event.getPlayer(), false, true)) event.setCanceled(true);
+    }
+
+    /**
+     * Shared gate for every interaction handler: server-side only, must be a non-spectator
+     * player inside an active locked cluster, and the relevant config flag must be on. The
+     * {@code right}/{@code left} flags pick which config switch applies.
+     */
+    private static boolean shouldBlockInteraction(Player player, boolean right, boolean left) {
+        if (player == null) return false;
+        if (player.level().isClientSide()) return false;
+        if (!(player instanceof ServerPlayer sp)) return false;
+        if (sp.isSpectator()) return false;
+        if (!isInsideLockedStructure(sp)) return false;
+        if (right && !Config.COMMON.structureBlockRightClick.get()) return false;
+        if (left && !Config.COMMON.structureBlockLeftClick.get()) return false;
+        return true;
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
+        // Prevents the per-UUID STATE map from growing forever as players cycle through.
+        clearPlayer(event.getEntity().getUUID());
     }
 }

--- a/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
@@ -20,8 +20,10 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.levelgen.structure.Structure;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.event.entity.ProjectileImpactEvent;
 import net.neoforged.neoforge.event.entity.player.AttackEntityEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
@@ -62,6 +64,10 @@ public class StructureLockHandler {
         List<StructureCluster> cachedActiveLockedClusters = Collections.emptyList();
         /** Hash of the last-sent border BB list, to skip redundant network sends. */
         int lastBorderHash = 0;
+        /** Last known outside-the-zone position (for wall-mode bounce-back). Null until first tick. */
+        Vec3 lastSafePos = null;
+        /** Whether the player was inside a locked zone on the previous tick (for wall-mode transition detection). */
+        boolean lastTickInside = false;
     }
 
     @SubscribeEvent
@@ -76,6 +82,13 @@ public class StructureLockHandler {
         int interval = Config.COMMON.structureCheckInterval.get();
         long chunkKey = (((long) player.chunkPosition().x) << 32) | (player.chunkPosition().z & 0xFFFFFFFFL);
         boolean chunkChanged = chunkKey != state.lastChunkKey;
+
+        // Wall-mode bounce runs BEFORE recompute so the player is teleported out before any
+        // damage/message handlers see them as "inside". Uses the previous tick's cached zones —
+        // safe because zones change only via recompute (chunk-change or interval).
+        if (Config.COMMON.structureWallMode.get()) {
+            applyWallMode(player, state);
+        }
 
         state.checkCooldown--;
         if (chunkChanged || state.checkCooldown <= 0) {
@@ -241,6 +254,54 @@ public class StructureLockHandler {
         applyContainment(player.blockPosition(), state);
     }
 
+    /**
+     * Wall-mode enforcement: bounces the player back to the last safe outside position when
+     * they cross a zone boundary INWARDS. Inside→outside and inside→inside moves are allowed
+     * so a player who was already trapped (logged out inside, then admin locked the stage)
+     * can still move around and escape; only fresh entry from outside is blocked.
+     */
+    private static void applyWallMode(ServerPlayer player, PlayerState state) {
+        Vec3 currentPos = player.position();
+        boolean insideNow = isPosInsideAnyLock(player.blockPosition(), state);
+
+        if (state.lastSafePos == null) {
+            // First-tick init: don't bounce regardless of where we are.
+            if (!insideNow) state.lastSafePos = currentPos;
+            state.lastTickInside = insideNow;
+            return;
+        }
+
+        if (insideNow && !state.lastTickInside) {
+            // Crossed from outside to inside this tick. Teleport back to the saved safe spot.
+            player.teleportTo(state.lastSafePos.x, state.lastSafePos.y, state.lastSafePos.z);
+            // Don't update lastSafePos / lastTickInside — after teleport the player is back outside.
+            return;
+        }
+
+        if (!insideNow) {
+            state.lastSafePos = currentPos;
+        }
+        state.lastTickInside = insideNow;
+    }
+
+    private static boolean isPosInsideAnyLock(BlockPos pos, PlayerState state) {
+        for (StructureCluster c : state.cachedLockedNearby) {
+            if (c.contains(pos)) return true;
+        }
+        return false;
+    }
+
+    /**
+     * True when the given block position lies inside any locked cluster cached for this player.
+     * Used by the anti-cheese block-pos checks: a player standing outside a zone shouldn't be
+     * able to mine into a village, interact with a chest poking through a wall, etc.
+     */
+    public static boolean isBlockInLockedZone(Player player, BlockPos pos) {
+        PlayerState state = STATE.get(player.getUUID());
+        if (state == null) return false;
+        return isPosInsideAnyLock(pos, state);
+    }
+
     private static void applyContainment(BlockPos pos, PlayerState state) {
         List<StructureCluster> active = new ArrayList<>();
         LinkedHashSet<String> activeStructureIds = new LinkedHashSet<>();
@@ -385,22 +446,22 @@ public class StructureLockHandler {
      */
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
-        if (shouldBlockInteraction(event.getEntity(), true, false)) event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), true, false, event.getPos())) event.setCanceled(true);
     }
 
     @SubscribeEvent
     public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
-        if (shouldBlockInteraction(event.getEntity(), true, false)) event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), true, false, null)) event.setCanceled(true);
     }
 
     @SubscribeEvent
     public static void onEntityInteract(PlayerInteractEvent.EntityInteract event) {
-        if (shouldBlockInteraction(event.getEntity(), true, false)) event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), true, false, event.getTarget().blockPosition())) event.setCanceled(true);
     }
 
     @SubscribeEvent
     public static void onEntityInteractSpecific(PlayerInteractEvent.EntityInteractSpecific event) {
-        if (shouldBlockInteraction(event.getEntity(), true, false)) event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), true, false, event.getTarget().blockPosition())) event.setCanceled(true);
     }
 
     /**
@@ -410,33 +471,59 @@ public class StructureLockHandler {
      */
     @SubscribeEvent
     public static void onLeftClickBlock(PlayerInteractEvent.LeftClickBlock event) {
-        if (shouldBlockInteraction(event.getEntity(), false, true)) event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), false, true, event.getPos())) event.setCanceled(true);
     }
 
     @SubscribeEvent
     public static void onAttackEntity(AttackEntityEvent event) {
-        if (shouldBlockInteraction(event.getEntity(), false, true)) event.setCanceled(true);
+        if (shouldBlockInteraction(event.getEntity(), false, true, event.getTarget().blockPosition())) event.setCanceled(true);
     }
 
     @SubscribeEvent
     public static void onBlockBreak(BlockEvent.BreakEvent event) {
-        if (shouldBlockInteraction(event.getPlayer(), false, true)) event.setCanceled(true);
+        if (shouldBlockInteraction(event.getPlayer(), false, true, event.getPos())) event.setCanceled(true);
     }
 
     /**
-     * Shared gate for every interaction handler: server-side only, must be a non-spectator
-     * player inside an active locked cluster, and the relevant config flag must be on. The
-     * {@code right}/{@code left} flags pick which config switch applies.
+     * Shared gate for every interaction handler. Triggers when the player is inside a locked
+     * zone OR when the target block/entity is inside one (anti-cheese: prevents mining or
+     * reaching into a zone from outside). Plus the per-side config flag must be on.
      */
-    private static boolean shouldBlockInteraction(Player player, boolean right, boolean left) {
+    private static boolean shouldBlockInteraction(Player player, boolean right, boolean left, BlockPos targetPos) {
         if (player == null) return false;
         if (player.level().isClientSide()) return false;
         if (!(player instanceof ServerPlayer sp)) return false;
         if (sp.isSpectator()) return false;
-        if (!isInsideLockedStructure(sp)) return false;
+
+        boolean playerInside = isInsideLockedStructure(sp);
+        boolean targetInside = targetPos != null && isBlockInLockedZone(sp, targetPos);
+        if (!playerInside && !targetInside) return false;
+
         if (right && !Config.COMMON.structureBlockRightClick.get()) return false;
         if (left && !Config.COMMON.structureBlockLeftClick.get()) return false;
         return true;
+    }
+
+    /**
+     * Cancels and discards projectiles whose impact would land inside a locked zone. Uses
+     * the shooter's cached lock geometry — projectiles without a player owner (e.g. dispenser
+     * arrows) are not checked. Gated by {@code structureBlockProjectiles}.
+     */
+    @SubscribeEvent
+    public static void onProjectileImpact(ProjectileImpactEvent event) {
+        if (event.getProjectile().level().isClientSide()) return;
+        if (!Config.COMMON.structureBlockProjectiles.get()) return;
+        if (!(event.getProjectile().getOwner() instanceof ServerPlayer shooter)) return;
+
+        PlayerState state = STATE.get(shooter.getUUID());
+        if (state == null || state.cachedLockedNearby.isEmpty()) return;
+
+        Vec3 hit = event.getRayTraceResult().getLocation();
+        BlockPos hitPos = BlockPos.containing(hit.x, hit.y, hit.z);
+        if (!isPosInsideAnyLock(hitPos, state)) return;
+
+        event.setCanceled(true);
+        event.getProjectile().discard();
     }
 
     @SubscribeEvent

--- a/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
@@ -219,11 +219,11 @@ public class StructureLockHandler {
         state.cachedLockedStageIds = new ArrayList<>(activeStageIds);
         state.cachedActiveLockedClusters = activeLocked;
 
-        // For border rendering we send one envelope per locked cluster — the union of all
-        // its lockShapes — so the client sees a single outer wall per village/dungeon
-        // instead of many small box faces.
-        List<BoundingBox> borderShapes = new ArrayList<>(lockedNearby.size());
-        for (StructureCluster c : lockedNearby) borderShapes.add(c.bounds());
+        // Send the full lockShape geometry to the client. The renderer culls interior faces
+        // (where a shape's face is occluded by another shape) so the force-field texture
+        // traces the actual silhouette of the orange union, not box-by-box.
+        List<BoundingBox> borderShapes = new ArrayList<>();
+        for (StructureCluster c : lockedNearby) borderShapes.addAll(c.lockShapes());
         syncBordersIfChanged(player, state, borderShapes);
     }
 

--- a/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/events/StructureLockHandler.java
@@ -18,11 +18,7 @@ import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.MenuProvider;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.SpawnerBlock;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.structure.Structure;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
@@ -348,21 +344,45 @@ public class StructureLockHandler {
         STATE.remove(uuid);
     }
 
+    /**
+     * Blanket-cancels every right-click interaction while the player is inside a locked
+     * structure: blocks (GUIs, doors, redstone, place-on-block), item self-use (eating,
+     * throwing pearls, drawing bows), and entity interactions (villager trading, mounting,
+     * item-frame insertion). The lock zone behaves like a no-touch museum case.
+     */
     @SubscribeEvent
     public static void onRightClickBlock(PlayerInteractEvent.RightClickBlock event) {
         if (event.getEntity().level().isClientSide()) return;
         if (!(event.getEntity() instanceof ServerPlayer player)) return;
         if (player.isSpectator()) return;
         if (!isInsideLockedStructure(player)) return;
+        event.setCanceled(true);
+    }
 
-        BlockState blockState = event.getLevel().getBlockState(event.getPos());
-        Block block = blockState.getBlock();
-        boolean hasGui = block instanceof MenuProvider
-                || event.getLevel().getBlockEntity(event.getPos()) instanceof MenuProvider;
-        boolean isSpawner = block instanceof SpawnerBlock;
+    @SubscribeEvent
+    public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
+        if (event.getEntity().level().isClientSide()) return;
+        if (!(event.getEntity() instanceof ServerPlayer player)) return;
+        if (player.isSpectator()) return;
+        if (!isInsideLockedStructure(player)) return;
+        event.setCanceled(true);
+    }
 
-        if (!hasGui && !isSpawner) return;
+    @SubscribeEvent
+    public static void onEntityInteract(PlayerInteractEvent.EntityInteract event) {
+        if (event.getEntity().level().isClientSide()) return;
+        if (!(event.getEntity() instanceof ServerPlayer player)) return;
+        if (player.isSpectator()) return;
+        if (!isInsideLockedStructure(player)) return;
+        event.setCanceled(true);
+    }
 
+    @SubscribeEvent
+    public static void onEntityInteractSpecific(PlayerInteractEvent.EntityInteractSpecific event) {
+        if (event.getEntity().level().isClientSide()) return;
+        if (!(event.getEntity() instanceof ServerPlayer player)) return;
+        if (player.isSpectator()) return;
+        if (!isInsideLockedStructure(player)) return;
         event.setCanceled(true);
     }
 }

--- a/src/main/java/net/bananemdnsa/historystages/network/PacketHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/PacketHandler.java
@@ -38,6 +38,8 @@ public class PacketHandler {
         registrar.playToServer(CheckDependencyPacket.TYPE, CheckDependencyPacket.STREAM_CODEC, CheckDependencyPacket::handle);
         registrar.playToServer(DepositDependencyPacket.TYPE, DepositDependencyPacket.STREAM_CODEC, DepositDependencyPacket::handle);
         registrar.playToServer(RequestStructureDebugPacket.TYPE, RequestStructureDebugPacket.STREAM_CODEC, RequestStructureDebugPacket::handle);
+        registrar.playToServer(ToggleStructureVizPacket.TYPE, ToggleStructureVizPacket.STREAM_CODEC, ToggleStructureVizPacket::handle);
+        registrar.playToServer(RequestClusterShapesPacket.TYPE, RequestClusterShapesPacket.STREAM_CODEC, RequestClusterShapesPacket::handle);
 
         // Dependency sync (Server → Client)
         registrar.playToClient(SyncDependencyStatusPacket.TYPE, SyncDependencyStatusPacket.STREAM_CODEC, SyncDependencyStatusPacket::handle);

--- a/src/main/java/net/bananemdnsa/historystages/network/PacketHandler.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/PacketHandler.java
@@ -49,6 +49,9 @@ public class PacketHandler {
 
         // Lock feedback (Server → Client) — client reads its own CLIENT config to decide display
         registrar.playToClient(LockFeedbackPacket.TYPE, LockFeedbackPacket.STREAM_CODEC, LockFeedbackPacket::handle);
+
+        // Lock border sync (Server → Client) — drives the force-field overlay near locked structures
+        registrar.playToClient(SyncLockBordersPacket.TYPE, SyncLockBordersPacket.STREAM_CODEC, SyncLockBordersPacket::handle);
     }
 
     public static void sendToAll(SyncStagesPacket packet) {
@@ -93,6 +96,10 @@ public class PacketHandler {
 
     // Send lock feedback (dimension or mob) to a specific player — client decides display
     public static void sendLockFeedbackToPlayer(LockFeedbackPacket packet, ServerPlayer player) {
+        PacketDistributor.sendToPlayer(player, packet);
+    }
+
+    public static void sendLockBordersToPlayer(SyncLockBordersPacket packet, ServerPlayer player) {
         PacketDistributor.sendToPlayer(player, packet);
     }
 

--- a/src/main/java/net/bananemdnsa/historystages/network/RequestClusterShapesPacket.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/RequestClusterShapesPacket.java
@@ -1,0 +1,148 @@
+package net.bananemdnsa.historystages.network;
+
+import net.bananemdnsa.historystages.Config;
+import net.bananemdnsa.historystages.HistoryStages;
+import net.bananemdnsa.historystages.structure.ClusterBuilder;
+import net.bananemdnsa.historystages.structure.StructureCluster;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.HoverEvent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+
+import java.util.List;
+
+/**
+ * Client-issued: dumps the current cluster + lockShape geometry around the player to chat.
+ * Used to diagnose unexpected huge lock zones — shows exactly which BBs are being treated
+ * as lock geometry and how big each one is. The header line is click-to-copy with the full
+ * plain-text report.
+ */
+public record RequestClusterShapesPacket() implements CustomPacketPayload {
+
+    public static final CustomPacketPayload.Type<RequestClusterShapesPacket> TYPE =
+            new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(HistoryStages.MOD_ID, "request_cluster_shapes"));
+
+    public static final StreamCodec<FriendlyByteBuf, RequestClusterShapesPacket> STREAM_CODEC =
+            StreamCodec.of((buf, msg) -> {}, buf -> new RequestClusterShapesPacket());
+
+    public static void handle(RequestClusterShapesPacket msg, IPayloadContext ctx) {
+        ctx.enqueueWork(() -> {
+            if (!(ctx.player() instanceof ServerPlayer player)) return;
+            if (!player.hasPermissions(2)) return;
+
+            int padding = Config.COMMON.structureLockPadding.get();
+            int clusterDistance = Config.COMMON.structureClusterDistance.get();
+            var pos = player.blockPosition();
+            List<StructureCluster> clusters = ClusterBuilder.collectClustersNear(
+                    player.serverLevel(), pos, 8, padding, clusterDistance);
+
+            StringBuilder plain = new StringBuilder();
+            plain.append("Cluster shapes at ").append(pos.getX()).append(", ").append(pos.getY())
+                    .append(", ").append(pos.getZ()).append('\n');
+            plain.append("padding=").append(padding).append(" clusterDistance=").append(clusterDistance).append('\n');
+
+            if (clusters.isEmpty()) {
+                plain.append("(no clusters near you)\n");
+            } else {
+                for (int i = 0; i < clusters.size(); i++) {
+                    StructureCluster c = clusters.get(i);
+                    String id = c.structure().unwrapKey().map(k -> k.location().toString()).orElse("<unknown>");
+                    plain.append("\n[Cluster ").append(i + 1).append("] ").append(id)
+                            .append(" — ").append(c.pieceBoxes().size()).append(" pieces, ")
+                            .append(c.lockShapes().size()).append(" lock shapes\n");
+                    plain.append("  envelope: ").append(formatBB(c.bounds()))
+                            .append(" (span ").append(spanStr(c.bounds())).append(")\n");
+                    plain.append("  pieces (largest first):\n");
+                    appendBoxes(plain, c.pieceBoxes(), 5);
+                    plain.append("  lockShapes (largest first):\n");
+                    appendBoxes(plain, c.lockShapes(), 5);
+                }
+            }
+
+            String plainReport = plain.toString();
+
+            // Header line is click-to-copy with the full report.
+            Component header = Component.literal("§6--- Cluster shapes §e[click to copy full report]§6 ---")
+                    .copy()
+                    .withStyle(Style.EMPTY
+                            .withClickEvent(new ClickEvent(ClickEvent.Action.COPY_TO_CLIPBOARD, plainReport))
+                            .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                                    Component.literal("Copy full report to clipboard")
+                                            .withStyle(ChatFormatting.GRAY))));
+            player.sendSystemMessage(header);
+
+            // Plus an in-chat readable version (truncated to top entries per cluster).
+            player.sendSystemMessage(Component.literal("§7Position: §f"
+                    + pos.getX() + ", " + pos.getY() + ", " + pos.getZ()
+                    + "  §7Config: §fpadding=" + padding + " clusterDistance=" + clusterDistance));
+
+            if (clusters.isEmpty()) {
+                player.sendSystemMessage(Component.literal("  §7(no clusters near you)"));
+                return;
+            }
+
+            for (int i = 0; i < clusters.size(); i++) {
+                StructureCluster c = clusters.get(i);
+                String id = c.structure().unwrapKey().map(k -> k.location().toString()).orElse("<unknown>");
+                player.sendSystemMessage(Component.literal(
+                        "§e[" + (i + 1) + "] §f" + id
+                                + " §7— " + c.pieceBoxes().size() + " pieces, "
+                                + c.lockShapes().size() + " shapes"));
+                player.sendSystemMessage(Component.literal(
+                        "  §8envelope: " + formatBB(c.bounds()) + " §7(" + spanStr(c.bounds()) + ")"));
+                List<BoundingBox> sortedShapes = c.lockShapes().stream()
+                        .sorted((a, b) -> Long.compare(volume(b), volume(a)))
+                        .toList();
+                int top = Math.min(3, sortedShapes.size());
+                for (int j = 0; j < top; j++) {
+                    BoundingBox bb = sortedShapes.get(j);
+                    player.sendSystemMessage(Component.literal(
+                            "  §8• " + spanStr(bb) + " §7" + formatBB(bb)));
+                }
+            }
+        });
+    }
+
+    private static void appendBoxes(StringBuilder sb, List<BoundingBox> boxes, int limit) {
+        List<BoundingBox> sorted = boxes.stream()
+                .sorted((a, b) -> Long.compare(volume(b), volume(a)))
+                .toList();
+        int max = Math.min(limit, sorted.size());
+        for (int i = 0; i < max; i++) {
+            BoundingBox bb = sorted.get(i);
+            sb.append("    ").append(spanStr(bb)).append("  ").append(formatBB(bb))
+                    .append("  vol=").append(volume(bb)).append('\n');
+        }
+        if (sorted.size() > max) {
+            sb.append("    ... +").append(sorted.size() - max).append(" more\n");
+        }
+    }
+
+    private static long volume(BoundingBox bb) {
+        long x = bb.maxX() - bb.minX() + 1L;
+        long y = bb.maxY() - bb.minY() + 1L;
+        long z = bb.maxZ() - bb.minZ() + 1L;
+        return x * y * z;
+    }
+
+    private static String spanStr(BoundingBox bb) {
+        return (bb.maxX() - bb.minX() + 1) + "x" + (bb.maxY() - bb.minY() + 1) + "x" + (bb.maxZ() - bb.minZ() + 1);
+    }
+
+    private static String formatBB(BoundingBox bb) {
+        return "(" + bb.minX() + "," + bb.minY() + "," + bb.minZ() + ")->(" + bb.maxX() + "," + bb.maxY() + "," + bb.maxZ() + ")";
+    }
+
+    @Override
+    public CustomPacketPayload.Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/net/bananemdnsa/historystages/network/SaveConfigPacket.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/SaveConfigPacket.java
@@ -112,6 +112,8 @@ public record SaveConfigPacket(Map<String, String> configValues, boolean isClien
                 case "structureLockInChat" -> Config.COMMON.structureLockInChat.set(Boolean.parseBoolean(value));
                 case "structureBlockRightClick" -> Config.COMMON.structureBlockRightClick.set(Boolean.parseBoolean(value));
                 case "structureBlockLeftClick" -> Config.COMMON.structureBlockLeftClick.set(Boolean.parseBoolean(value));
+                case "structureWallMode" -> Config.COMMON.structureWallMode.set(Boolean.parseBoolean(value));
+                case "structureBlockProjectiles" -> Config.COMMON.structureBlockProjectiles.set(Boolean.parseBoolean(value));
                 case "msgDimensionUnknown" -> Config.COMMON.msgDimensionUnknown.set(value);
                 case "msgMobUnknown" -> Config.COMMON.msgMobUnknown.set(value);
                 case "msgItemLocked" -> Config.COMMON.msgItemLocked.set(value);

--- a/src/main/java/net/bananemdnsa/historystages/network/SaveConfigPacket.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/SaveConfigPacket.java
@@ -110,6 +110,8 @@ public record SaveConfigPacket(Map<String, String> configValues, boolean isClien
                 case "structureMessageEnabled" -> Config.COMMON.structureMessageEnabled.set(Boolean.parseBoolean(value));
                 case "structureLockMessageFormat" -> Config.COMMON.structureLockMessageFormat.set(value);
                 case "structureLockInChat" -> Config.COMMON.structureLockInChat.set(Boolean.parseBoolean(value));
+                case "structureBlockRightClick" -> Config.COMMON.structureBlockRightClick.set(Boolean.parseBoolean(value));
+                case "structureBlockLeftClick" -> Config.COMMON.structureBlockLeftClick.set(Boolean.parseBoolean(value));
                 case "msgDimensionUnknown" -> Config.COMMON.msgDimensionUnknown.set(value);
                 case "msgMobUnknown" -> Config.COMMON.msgMobUnknown.set(value);
                 case "msgItemLocked" -> Config.COMMON.msgItemLocked.set(value);

--- a/src/main/java/net/bananemdnsa/historystages/network/SaveConfigPacket.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/SaveConfigPacket.java
@@ -112,7 +112,6 @@ public record SaveConfigPacket(Map<String, String> configValues, boolean isClien
                 case "structureLockInChat" -> Config.COMMON.structureLockInChat.set(Boolean.parseBoolean(value));
                 case "structureBlockRightClick" -> Config.COMMON.structureBlockRightClick.set(Boolean.parseBoolean(value));
                 case "structureBlockLeftClick" -> Config.COMMON.structureBlockLeftClick.set(Boolean.parseBoolean(value));
-                case "structureWallMode" -> Config.COMMON.structureWallMode.set(Boolean.parseBoolean(value));
                 case "structureBlockProjectiles" -> Config.COMMON.structureBlockProjectiles.set(Boolean.parseBoolean(value));
                 case "msgDimensionUnknown" -> Config.COMMON.msgDimensionUnknown.set(value);
                 case "msgMobUnknown" -> Config.COMMON.msgMobUnknown.set(value);

--- a/src/main/java/net/bananemdnsa/historystages/network/SyncConfigPacket.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/SyncConfigPacket.java
@@ -79,7 +79,6 @@ public record SyncConfigPacket(Map<String, String> configValues) implements Cust
         values.put("structureLockInChat", Config.COMMON.structureLockInChat.get().toString());
         values.put("structureBlockRightClick", Config.COMMON.structureBlockRightClick.get().toString());
         values.put("structureBlockLeftClick", Config.COMMON.structureBlockLeftClick.get().toString());
-        values.put("structureWallMode", Config.COMMON.structureWallMode.get().toString());
         values.put("structureBlockProjectiles", Config.COMMON.structureBlockProjectiles.get().toString());
         values.put("msgDimensionUnknown", Config.COMMON.msgDimensionUnknown.get());
         values.put("msgMobUnknown", Config.COMMON.msgMobUnknown.get());

--- a/src/main/java/net/bananemdnsa/historystages/network/SyncConfigPacket.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/SyncConfigPacket.java
@@ -77,6 +77,8 @@ public record SyncConfigPacket(Map<String, String> configValues) implements Cust
         values.put("structureMessageEnabled", Config.COMMON.structureMessageEnabled.get().toString());
         values.put("structureLockMessageFormat", Config.COMMON.structureLockMessageFormat.get());
         values.put("structureLockInChat", Config.COMMON.structureLockInChat.get().toString());
+        values.put("structureBlockRightClick", Config.COMMON.structureBlockRightClick.get().toString());
+        values.put("structureBlockLeftClick", Config.COMMON.structureBlockLeftClick.get().toString());
         values.put("msgDimensionUnknown", Config.COMMON.msgDimensionUnknown.get());
         values.put("msgMobUnknown", Config.COMMON.msgMobUnknown.get());
         values.put("msgItemLocked", Config.COMMON.msgItemLocked.get());

--- a/src/main/java/net/bananemdnsa/historystages/network/SyncConfigPacket.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/SyncConfigPacket.java
@@ -79,6 +79,8 @@ public record SyncConfigPacket(Map<String, String> configValues) implements Cust
         values.put("structureLockInChat", Config.COMMON.structureLockInChat.get().toString());
         values.put("structureBlockRightClick", Config.COMMON.structureBlockRightClick.get().toString());
         values.put("structureBlockLeftClick", Config.COMMON.structureBlockLeftClick.get().toString());
+        values.put("structureWallMode", Config.COMMON.structureWallMode.get().toString());
+        values.put("structureBlockProjectiles", Config.COMMON.structureBlockProjectiles.get().toString());
         values.put("msgDimensionUnknown", Config.COMMON.msgDimensionUnknown.get());
         values.put("msgMobUnknown", Config.COMMON.msgMobUnknown.get());
         values.put("msgItemLocked", Config.COMMON.msgItemLocked.get());

--- a/src/main/java/net/bananemdnsa/historystages/network/SyncLockBordersPacket.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/SyncLockBordersPacket.java
@@ -1,0 +1,62 @@
+package net.bananemdnsa.historystages.network;
+
+import net.bananemdnsa.historystages.HistoryStages;
+import net.bananemdnsa.historystages.client.LockBorderClientCache;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Server -> client: the set of {@link BoundingBox}es the player is currently gated by.
+ * The client renders a force-field overlay on the faces of these boxes when the player
+ * approaches them.
+ */
+public record SyncLockBordersPacket(List<BoundingBox> boxes) implements CustomPacketPayload {
+
+    public static final CustomPacketPayload.Type<SyncLockBordersPacket> TYPE =
+            new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(HistoryStages.MOD_ID, "sync_lock_borders"));
+
+    public static final StreamCodec<FriendlyByteBuf, SyncLockBordersPacket> STREAM_CODEC = StreamCodec.of(
+            (buf, msg) -> {
+                buf.writeVarInt(msg.boxes.size());
+                for (BoundingBox bb : msg.boxes) {
+                    buf.writeInt(bb.minX());
+                    buf.writeInt(bb.minY());
+                    buf.writeInt(bb.minZ());
+                    buf.writeInt(bb.maxX());
+                    buf.writeInt(bb.maxY());
+                    buf.writeInt(bb.maxZ());
+                }
+            },
+            buf -> {
+                int n = buf.readVarInt();
+                List<BoundingBox> boxes = new ArrayList<>(n);
+                for (int i = 0; i < n; i++) {
+                    int minX = buf.readInt(), minY = buf.readInt(), minZ = buf.readInt();
+                    int maxX = buf.readInt(), maxY = buf.readInt(), maxZ = buf.readInt();
+                    boxes.add(new BoundingBox(minX, minY, minZ, maxX, maxY, maxZ));
+                }
+                return new SyncLockBordersPacket(boxes);
+            }
+    );
+
+    public static void handle(SyncLockBordersPacket msg, IPayloadContext ctx) {
+        ctx.enqueueWork(() -> {
+            if (FMLEnvironment.dist != Dist.CLIENT) return;
+            LockBorderClientCache.set(msg.boxes);
+        });
+    }
+
+    @Override
+    public CustomPacketPayload.Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/net/bananemdnsa/historystages/network/ToggleStructureVizPacket.java
+++ b/src/main/java/net/bananemdnsa/historystages/network/ToggleStructureVizPacket.java
@@ -1,0 +1,40 @@
+package net.bananemdnsa.historystages.network;
+
+import net.bananemdnsa.historystages.HistoryStages;
+import net.bananemdnsa.historystages.structure.ClusterDebugRenderer;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+
+/**
+ * Client-issued: toggle the structure-cluster debug visualization for the requesting player.
+ * Server stores the opt-in state and emits per-player particles outlining piece + cluster bounds.
+ */
+public record ToggleStructureVizPacket() implements CustomPacketPayload {
+
+    public static final CustomPacketPayload.Type<ToggleStructureVizPacket> TYPE =
+            new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(HistoryStages.MOD_ID, "toggle_structure_viz"));
+
+    public static final StreamCodec<FriendlyByteBuf, ToggleStructureVizPacket> STREAM_CODEC =
+            StreamCodec.of((buf, msg) -> {}, buf -> new ToggleStructureVizPacket());
+
+    public static void handle(ToggleStructureVizPacket msg, IPayloadContext ctx) {
+        ctx.enqueueWork(() -> {
+            if (!(ctx.player() instanceof ServerPlayer player)) return;
+            if (!player.hasPermissions(2)) return;
+            boolean nowEnabled = ClusterDebugRenderer.toggle(player.getUUID());
+            player.sendSystemMessage(Component.literal(nowEnabled
+                    ? "§aStructure cluster visualization §lENABLED§a — particles will appear when near locked structures."
+                    : "§7Structure cluster visualization §lDISABLED§7."));
+        });
+    }
+
+    @Override
+    public CustomPacketPayload.Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+}

--- a/src/main/java/net/bananemdnsa/historystages/structure/ClusterBuilder.java
+++ b/src/main/java/net/bananemdnsa/historystages/structure/ClusterBuilder.java
@@ -1,0 +1,242 @@
+package net.bananemdnsa.historystages.structure;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.minecraft.world.level.levelgen.structure.Structure;
+import net.minecraft.world.level.levelgen.structure.StructureStart;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds {@link StructureCluster}s for every structure start within a chunk radius
+ * of a position. The resulting lock area is a union of axis-aligned boxes:
+ * <ul>
+ *   <li>each structure piece, inflated by {@code padding},</li>
+ *   <li>plus a small connector box between every pair of pieces whose pair-distance
+ *       (Chebyshev / per-axis max gap) is &le; {@code clusterDistance}.</li>
+ * </ul>
+ * The union of these shapes traces the structure's actual geometry instead of
+ * collapsing into one giant rectangle, so e.g. a desert village turns into
+ * house-shaped zones linked by thin paths/connectors.
+ */
+public final class ClusterBuilder {
+
+    private ClusterBuilder() {}
+
+    public static List<StructureCluster> collectClustersNear(
+            ServerLevel level,
+            BlockPos center,
+            int chunkRadius,
+            int padding,
+            int clusterDistance
+    ) {
+        Registry<Structure> registry = level.registryAccess().registryOrThrow(Registries.STRUCTURE);
+        ChunkPos centerChunk = new ChunkPos(center);
+
+        Map<StructureStart, Structure> starts = new LinkedHashMap<>();
+        for (int cx = centerChunk.x - chunkRadius; cx <= centerChunk.x + chunkRadius; cx++) {
+            for (int cz = centerChunk.z - chunkRadius; cz <= centerChunk.z + chunkRadius; cz++) {
+                ChunkAccess chunk = level.getChunkSource().getChunkNow(cx, cz);
+                if (chunk == null) continue;
+                for (Map.Entry<Structure, StructureStart> e : chunk.getAllStarts().entrySet()) {
+                    StructureStart start = e.getValue();
+                    if (start == null || !start.isValid()) continue;
+                    starts.putIfAbsent(start, e.getKey());
+                }
+            }
+        }
+
+        if (starts.isEmpty()) return List.of();
+
+        List<StructureCluster> result = new ArrayList<>();
+        for (Map.Entry<StructureStart, Structure> entry : starts.entrySet()) {
+            Holder.Reference<Structure> holder = resolveHolder(registry, entry.getValue());
+            if (holder == null) continue;
+            buildFor(entry.getKey(), holder, padding, clusterDistance, result);
+        }
+        return result;
+    }
+
+    private static Holder.Reference<Structure> resolveHolder(Registry<Structure> registry, Structure structure) {
+        var key = registry.getKey(structure);
+        if (key == null) return null;
+        return registry.getHolder(ResourceKey.create(Registries.STRUCTURE, key)).orElse(null);
+    }
+
+    private static void buildFor(
+            StructureStart start,
+            Holder.Reference<Structure> holder,
+            int padding,
+            int clusterDistance,
+            List<StructureCluster> out
+    ) {
+        List<BoundingBox> rawPieces = new ArrayList<>(start.getPieces().size());
+        for (var piece : start.getPieces()) {
+            rawPieces.add(piece.getBoundingBox());
+        }
+        if (rawPieces.isEmpty()) return;
+
+        // Drop "umbrella" pieces — a piece whose BB strictly contains another piece's BB.
+        // Some structures (modded villages, plot-marker structures, jigsaw "claim" pieces)
+        // include a single giant piece that encompasses the whole structure for layout
+        // purposes. Without filtering, that piece would be drawn as a huge orange box
+        // outside the actual rooms and would trigger the lock when entered.
+        List<BoundingBox> pieceBoxes = new ArrayList<>(rawPieces.size());
+        for (int i = 0; i < rawPieces.size(); i++) {
+            BoundingBox candidate = rawPieces.get(i);
+            boolean isUmbrella = false;
+            for (int j = 0; j < rawPieces.size(); j++) {
+                if (i == j) continue;
+                if (strictlyContains(candidate, rawPieces.get(j))) {
+                    isUmbrella = true;
+                    break;
+                }
+            }
+            if (!isUmbrella) pieceBoxes.add(candidate);
+        }
+        if (pieceBoxes.isEmpty()) pieceBoxes = rawPieces; // safety fallback
+
+        // 1. Group pieces into clusters via union-find on pair-distance ≤ clusterDistance.
+        int n = pieceBoxes.size();
+        int[] parent = new int[n];
+        for (int i = 0; i < n; i++) parent[i] = i;
+        for (int i = 0; i < n; i++) {
+            for (int j = i + 1; j < n; j++) {
+                if (find(parent, i) == find(parent, j)) continue;
+                if (pieceDistance(pieceBoxes.get(i), pieceBoxes.get(j)) <= clusterDistance) {
+                    union(parent, i, j);
+                }
+            }
+        }
+
+        Map<Integer, List<Integer>> groups = new LinkedHashMap<>();
+        for (int i = 0; i < n; i++) {
+            groups.computeIfAbsent(find(parent, i), k -> new ArrayList<>()).add(i);
+        }
+
+        // 2. For each cluster, build lockShapes = inflated pieces + connectors between
+        //    nearby pieces within the cluster.
+        for (List<Integer> indices : groups.values()) {
+            List<BoundingBox> originals = new ArrayList<>(indices.size());
+            List<BoundingBox> shapes = new ArrayList<>();
+
+            for (int idx : indices) {
+                BoundingBox piece = pieceBoxes.get(idx);
+                originals.add(piece);
+                shapes.add(padding > 0 ? piece.inflatedBy(padding) : piece);
+            }
+
+            // Connectors between every nearby pair in this cluster.
+            for (int a = 0; a < indices.size(); a++) {
+                for (int b = a + 1; b < indices.size(); b++) {
+                    BoundingBox pa = pieceBoxes.get(indices.get(a));
+                    BoundingBox pb = pieceBoxes.get(indices.get(b));
+                    if (pieceDistance(pa, pb) > clusterDistance) continue;
+                    BoundingBox connector = buildConnector(pa, pb, padding);
+                    if (connector != null) shapes.add(connector);
+                }
+            }
+
+            // NOTE: BoundingBox#encapsulate mutates `this` in-place in vanilla 1.21, so
+            // chaining it on shapes.get(0) would silently rewrite the first shape into
+            // the cluster envelope. Compute the envelope manually instead.
+            int minX = Integer.MAX_VALUE, minY = Integer.MAX_VALUE, minZ = Integer.MAX_VALUE;
+            int maxX = Integer.MIN_VALUE, maxY = Integer.MIN_VALUE, maxZ = Integer.MIN_VALUE;
+            for (BoundingBox s : shapes) {
+                if (s.minX() < minX) minX = s.minX();
+                if (s.minY() < minY) minY = s.minY();
+                if (s.minZ() < minZ) minZ = s.minZ();
+                if (s.maxX() > maxX) maxX = s.maxX();
+                if (s.maxY() > maxY) maxY = s.maxY();
+                if (s.maxZ() > maxZ) maxZ = s.maxZ();
+            }
+            BoundingBox bounds = new BoundingBox(minX, minY, minZ, maxX, maxY, maxZ);
+
+            out.add(new StructureCluster(bounds, holder, List.copyOf(originals), List.copyOf(shapes)));
+        }
+    }
+
+    /**
+     * Builds a connector box bridging two pieces along a single axis.
+     * <ul>
+     *   <li>If the pieces overlap in every axis: no connector needed, returns {@code null}.</li>
+     *   <li>If they are separated in exactly one axis: connector spans the gap in that
+     *       axis and the natural piece overlap in the perpendicular axes — the bridge is
+     *       as wide as the two pieces have in common, never wider.</li>
+     *   <li>If they are separated in two or more axes (diagonal): no connector. Otherwise
+     *       grid-arranged pieces would fill in their diagonals and recreate one big box.</li>
+     * </ul>
+     */
+    private static BoundingBox buildConnector(BoundingBox a, BoundingBox b, int padding) {
+        int xGap = axisGap(a.minX(), a.maxX(), b.minX(), b.maxX());
+        int yGap = axisGap(a.minY(), a.maxY(), b.minY(), b.maxY());
+        int zGap = axisGap(a.minZ(), a.maxZ(), b.minZ(), b.maxZ());
+        int separatedAxes = (xGap > 0 ? 1 : 0) + (yGap > 0 ? 1 : 0) + (zGap > 0 ? 1 : 0);
+        if (separatedAxes == 0) return null;
+        if (separatedAxes >= 2) return null;
+
+        int[] x = axisSpan(a.minX(), a.maxX(), b.minX(), b.maxX());
+        int[] y = axisSpan(a.minY(), a.maxY(), b.minY(), b.maxY());
+        int[] z = axisSpan(a.minZ(), a.maxZ(), b.minZ(), b.maxZ());
+
+        BoundingBox connector = new BoundingBox(x[0], y[0], z[0], x[1], y[1], z[1]);
+        return padding > 0 ? connector.inflatedBy(padding) : connector;
+    }
+
+    /** True when {@code outer}'s BB fully contains {@code inner}'s BB and the two are not equal. */
+    private static boolean strictlyContains(BoundingBox outer, BoundingBox inner) {
+        boolean contains =
+                outer.minX() <= inner.minX() && outer.maxX() >= inner.maxX() &&
+                outer.minY() <= inner.minY() && outer.maxY() >= inner.maxY() &&
+                outer.minZ() <= inner.minZ() && outer.maxZ() >= inner.maxZ();
+        if (!contains) return false;
+        boolean equal =
+                outer.minX() == inner.minX() && outer.maxX() == inner.maxX() &&
+                outer.minY() == inner.minY() && outer.maxY() == inner.maxY() &&
+                outer.minZ() == inner.minZ() && outer.maxZ() == inner.maxZ();
+        return !equal;
+    }
+
+    private static int[] axisSpan(int aMin, int aMax, int bMin, int bMax) {
+        if (aMax < bMin) return new int[]{aMax, bMin};
+        if (bMax < aMin) return new int[]{bMax, aMin};
+        return new int[]{Math.max(aMin, bMin), Math.min(aMax, bMax)};
+    }
+
+    /** Chebyshev distance between two axis-aligned BBs (0 if they overlap). */
+    private static int pieceDistance(BoundingBox a, BoundingBox b) {
+        int dx = axisGap(a.minX(), a.maxX(), b.minX(), b.maxX());
+        int dy = axisGap(a.minY(), a.maxY(), b.minY(), b.maxY());
+        int dz = axisGap(a.minZ(), a.maxZ(), b.minZ(), b.maxZ());
+        return Math.max(Math.max(dx, dy), dz);
+    }
+
+    private static int axisGap(int aMin, int aMax, int bMin, int bMax) {
+        if (aMax < bMin) return bMin - aMax;
+        if (bMax < aMin) return aMin - bMax;
+        return 0;
+    }
+
+    private static int find(int[] parent, int i) {
+        while (parent[i] != i) {
+            parent[i] = parent[parent[i]];
+            i = parent[i];
+        }
+        return i;
+    }
+
+    private static void union(int[] parent, int a, int b) {
+        int ra = find(parent, a), rb = find(parent, b);
+        if (ra != rb) parent[ra] = rb;
+    }
+}

--- a/src/main/java/net/bananemdnsa/historystages/structure/ClusterBuilder.java
+++ b/src/main/java/net/bananemdnsa/historystages/structure/ClusterBuilder.java
@@ -13,23 +13,57 @@ import net.minecraft.world.level.levelgen.structure.Structure;
 import net.minecraft.world.level.levelgen.structure.StructureStart;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
- * Builds {@link StructureCluster}s for every structure start within a chunk radius
- * of a position. The resulting lock area is a union of axis-aligned boxes:
- * <ul>
- *   <li>each structure piece, inflated by {@code padding},</li>
- *   <li>plus a small connector box between every pair of pieces whose pair-distance
- *       (Chebyshev / per-axis max gap) is &le; {@code clusterDistance}.</li>
- * </ul>
- * The union of these shapes traces the structure's actual geometry instead of
- * collapsing into one giant rectangle, so e.g. a desert village turns into
- * house-shaped zones linked by thin paths/connectors.
+ * Builds {@link StructureCluster}s by growing a zone outward from a seed piece.
+ *
+ * <p>Algorithm per structure start:
+ * <ol>
+ *   <li>Filter out "umbrella" pieces (any piece whose BB strictly contains another piece's BB).
+ *       These appear in modded villages / jigsaw plot markers and would otherwise drag a giant
+ *       envelope into the zone.</li>
+ *   <li>Pick an unassigned piece as the seed; the zone starts as that piece inflated by
+ *       {@code padding} (the "orange box").</li>
+ *   <li><b>Overlap merge</b>: absorb every remaining piece whose raw BB intersects any shape in
+ *       the zone. Repeat until no piece overlaps. The zone is allowed to take any non-convex
+ *       shape (L, T, hollow, etc.) — it's stored as a union of axis-aligned boxes.</li>
+ *   <li><b>Bridge phase</b>: search outward by {@code clusterDistance} (default 6 blocks, "wenn
+ *       wir in diesem Radius eine weitere PieceBB finden"). For the first remaining piece within
+ *       reach, build a connector bridge BB (single-axis) or an L-shaped pair (two-axis diagonal),
+ *       absorb the bridge and the piece. <b>Restart from step 3 after every bridge added</b> —
+ *       the new piece might overlap others and the 6-block search must be re-evaluated against
+ *       the grown zone.</li>
+ *   <li>When no more pieces overlap or are within reach, emit the cluster and start over with
+ *       a new seed.</li>
+ * </ol>
+ *
+ * <p><b>"3-Block-Erweiterung" (3-block height expansion):</b>
+ * After a zone is finalized, the union is scanned per (x,z) column. For each contiguous
+ * occupied Y-interval whose height is &lt; 3 blocks, a cap box is added on top so the union
+ * is 3 blocks thick there. Cap boxes are then greedily merged into the minimum number of
+ * rectangles (strip merge along Z then X) so the renderer doesn't get spammed with tiny
+ * 1×1×N boxes. Only the topmost thin interval per column gets capped — capping a lower
+ * thin interval would intrude into shapes above it.
  */
 public final class ClusterBuilder {
+
+    /** Minimum Y-thickness of a lock shape after the height-expansion pass. */
+    private static final int MIN_LOCK_HEIGHT = 5;
+
+    /**
+     * Extra padding added to every piece BEFORE overlap-merge and bridging — a safety wall
+     * between the actual structure blocks and the player. Stacks on top of the configured
+     * {@code structureLockPadding} so even with config = 0 there's always a buffer. Because
+     * this widens every seed shape, the overlap step naturally absorbs pieces that were close
+     * but not quite touching, and the bridge step bridges across the (now-larger) zone.
+     */
+    private static final int SAFETY_PADDING = 2;
 
     private ClusterBuilder() {}
 
@@ -80,120 +114,354 @@ public final class ClusterBuilder {
             int clusterDistance,
             List<StructureCluster> out
     ) {
-        List<BoundingBox> rawPieces = new ArrayList<>(start.getPieces().size());
-        for (var piece : start.getPieces()) {
-            rawPieces.add(piece.getBoundingBox());
-        }
-        if (rawPieces.isEmpty()) return;
+        // Safety-wall buffer applied to every piece before overlap-merge and bridging so
+        // there's always a gap between the actual structure blocks and where the lock kicks in.
+        int effectivePadding = padding + SAFETY_PADDING;
 
-        // Drop "umbrella" pieces — a piece whose BB strictly contains another piece's BB.
-        // Some structures (modded villages, plot-marker structures, jigsaw "claim" pieces)
-        // include a single giant piece that encompasses the whole structure for layout
-        // purposes. Without filtering, that piece would be drawn as a huge orange box
-        // outside the actual rooms and would trigger the lock when entered.
-        List<BoundingBox> pieceBoxes = new ArrayList<>(rawPieces.size());
-        for (int i = 0; i < rawPieces.size(); i++) {
-            BoundingBox candidate = rawPieces.get(i);
+        List<BoundingBox> pieces = filterUmbrellaPieces(start);
+        if (pieces.isEmpty()) return;
+
+        Set<Integer> remaining = new LinkedHashSet<>();
+        for (int i = 0; i < pieces.size(); i++) remaining.add(i);
+
+        while (!remaining.isEmpty()) {
+            int seed = remaining.iterator().next();
+            remaining.remove(seed);
+
+            List<BoundingBox> zonePieces = new ArrayList<>();
+            List<BoundingBox> zoneShapes = new ArrayList<>();
+            absorbPiece(pieces.get(seed), effectivePadding, zonePieces, zoneShapes);
+
+            // Alternate overlap-merge and bridge until neither can grow the zone further.
+            while (true) {
+                drainOverlapping(pieces, remaining, zonePieces, zoneShapes, effectivePadding);
+
+                BridgeCandidate bc = findNearestBridge(pieces, remaining, zoneShapes, clusterDistance, effectivePadding);
+                if (bc == null) break;
+
+                remaining.remove(bc.pieceIndex);
+                zoneShapes.addAll(bc.bridgeShapes);
+                absorbPiece(pieces.get(bc.pieceIndex), effectivePadding, zonePieces, zoneShapes);
+                // Loop restarts: new piece may overlap others; 6-block search re-runs from the
+                // now-larger zone.
+            }
+
+            List<BoundingBox> finalShapes = ensureMinHeight(zoneShapes, MIN_LOCK_HEIGHT);
+            out.add(new StructureCluster(
+                    envelopeOf(finalShapes),
+                    holder,
+                    List.copyOf(zonePieces),
+                    List.copyOf(finalShapes)
+            ));
+        }
+    }
+
+    /** Drops pieces whose BB strictly contains another piece's BB (modded jigsaw "claim" pieces). */
+    private static List<BoundingBox> filterUmbrellaPieces(StructureStart start) {
+        List<BoundingBox> raw = new ArrayList<>(start.getPieces().size());
+        for (var piece : start.getPieces()) raw.add(piece.getBoundingBox());
+        if (raw.isEmpty()) return raw;
+
+        List<BoundingBox> filtered = new ArrayList<>(raw.size());
+        for (int i = 0; i < raw.size(); i++) {
+            BoundingBox candidate = raw.get(i);
             boolean isUmbrella = false;
-            for (int j = 0; j < rawPieces.size(); j++) {
+            for (int j = 0; j < raw.size(); j++) {
                 if (i == j) continue;
-                if (strictlyContains(candidate, rawPieces.get(j))) {
+                if (strictlyContains(candidate, raw.get(j))) {
                     isUmbrella = true;
                     break;
                 }
             }
-            if (!isUmbrella) pieceBoxes.add(candidate);
+            if (!isUmbrella) filtered.add(candidate);
         }
-        if (pieceBoxes.isEmpty()) pieceBoxes = rawPieces; // safety fallback
+        return filtered.isEmpty() ? raw : filtered;
+    }
 
-        // 1. Group pieces into clusters via union-find on pair-distance ≤ clusterDistance.
-        int n = pieceBoxes.size();
-        int[] parent = new int[n];
-        for (int i = 0; i < n; i++) parent[i] = i;
-        for (int i = 0; i < n; i++) {
-            for (int j = i + 1; j < n; j++) {
-                if (find(parent, i) == find(parent, j)) continue;
-                if (pieceDistance(pieceBoxes.get(i), pieceBoxes.get(j)) <= clusterDistance) {
-                    union(parent, i, j);
+    private static void absorbPiece(BoundingBox piece, int padding,
+                                    List<BoundingBox> zonePieces, List<BoundingBox> zoneShapes) {
+        zonePieces.add(piece);
+        zoneShapes.add(padding > 0 ? piece.inflatedBy(padding) : piece);
+    }
+
+    /** Absorbs every remaining piece whose raw BB intersects any shape in the current zone. */
+    private static void drainOverlapping(List<BoundingBox> pieces, Set<Integer> remaining,
+                                         List<BoundingBox> zonePieces, List<BoundingBox> zoneShapes,
+                                         int padding) {
+        boolean grew = true;
+        while (grew) {
+            grew = false;
+            Integer hit = null;
+            for (int idx : remaining) {
+                BoundingBox piece = pieces.get(idx);
+                for (BoundingBox shape : zoneShapes) {
+                    if (intersects(piece, shape)) {
+                        hit = idx;
+                        break;
+                    }
+                }
+                if (hit != null) break;
+            }
+            if (hit != null) {
+                remaining.remove(hit);
+                absorbPiece(pieces.get(hit), padding, zonePieces, zoneShapes);
+                grew = true;
+            }
+        }
+    }
+
+    private record BridgeCandidate(int pieceIndex, List<BoundingBox> bridgeShapes) {}
+
+    /**
+     * Finds the first remaining piece within {@code maxDistance} of any zone shape and builds
+     * the bridge BB(s) to connect them. Returns {@code null} if nothing is within reach.
+     */
+    private static BridgeCandidate findNearestBridge(List<BoundingBox> pieces, Set<Integer> remaining,
+                                                     List<BoundingBox> zoneShapes, int maxDistance,
+                                                     int padding) {
+        for (int idx : remaining) {
+            BoundingBox piece = pieces.get(idx);
+            BoundingBox bestShape = null;
+            int bestDist = Integer.MAX_VALUE;
+            for (BoundingBox shape : zoneShapes) {
+                int d = pieceDistance(shape, piece);
+                if (d <= maxDistance && d < bestDist) {
+                    bestDist = d;
+                    bestShape = shape;
                 }
             }
+            if (bestShape == null) continue;
+
+            List<BoundingBox> bridges = buildBridge(bestShape, piece, padding);
+            // Diagonal in all 3 axes is skipped (rare); such pieces typically get reached via
+            // an intermediate piece in a later iteration.
+            if (bridges.isEmpty()) continue;
+
+            return new BridgeCandidate(idx, bridges);
         }
-
-        Map<Integer, List<Integer>> groups = new LinkedHashMap<>();
-        for (int i = 0; i < n; i++) {
-            groups.computeIfAbsent(find(parent, i), k -> new ArrayList<>()).add(i);
-        }
-
-        // 2. For each cluster, build lockShapes = inflated pieces + connectors between
-        //    nearby pieces within the cluster.
-        for (List<Integer> indices : groups.values()) {
-            List<BoundingBox> originals = new ArrayList<>(indices.size());
-            List<BoundingBox> shapes = new ArrayList<>();
-
-            for (int idx : indices) {
-                BoundingBox piece = pieceBoxes.get(idx);
-                originals.add(piece);
-                shapes.add(padding > 0 ? piece.inflatedBy(padding) : piece);
-            }
-
-            // Connectors between every nearby pair in this cluster.
-            for (int a = 0; a < indices.size(); a++) {
-                for (int b = a + 1; b < indices.size(); b++) {
-                    BoundingBox pa = pieceBoxes.get(indices.get(a));
-                    BoundingBox pb = pieceBoxes.get(indices.get(b));
-                    if (pieceDistance(pa, pb) > clusterDistance) continue;
-                    BoundingBox connector = buildConnector(pa, pb, padding);
-                    if (connector != null) shapes.add(connector);
-                }
-            }
-
-            // NOTE: BoundingBox#encapsulate mutates `this` in-place in vanilla 1.21, so
-            // chaining it on shapes.get(0) would silently rewrite the first shape into
-            // the cluster envelope. Compute the envelope manually instead.
-            int minX = Integer.MAX_VALUE, minY = Integer.MAX_VALUE, minZ = Integer.MAX_VALUE;
-            int maxX = Integer.MIN_VALUE, maxY = Integer.MIN_VALUE, maxZ = Integer.MIN_VALUE;
-            for (BoundingBox s : shapes) {
-                if (s.minX() < minX) minX = s.minX();
-                if (s.minY() < minY) minY = s.minY();
-                if (s.minZ() < minZ) minZ = s.minZ();
-                if (s.maxX() > maxX) maxX = s.maxX();
-                if (s.maxY() > maxY) maxY = s.maxY();
-                if (s.maxZ() > maxZ) maxZ = s.maxZ();
-            }
-            BoundingBox bounds = new BoundingBox(minX, minY, minZ, maxX, maxY, maxZ);
-
-            out.add(new StructureCluster(bounds, holder, List.copyOf(originals), List.copyOf(shapes)));
-        }
+        return null;
     }
 
     /**
-     * Builds a connector box bridging two pieces along a single axis.
+     * Builds connector BBs between two boxes:
      * <ul>
-     *   <li>If the pieces overlap in every axis: no connector needed, returns {@code null}.</li>
-     *   <li>If they are separated in exactly one axis: connector spans the gap in that
-     *       axis and the natural piece overlap in the perpendicular axes — the bridge is
-     *       as wide as the two pieces have in common, never wider.</li>
-     *   <li>If they are separated in two or more axes (diagonal): no connector. Otherwise
-     *       grid-arranged pieces would fill in their diagonals and recreate one big box.</li>
+     *   <li>0 axes separated → already overlapping, no bridge needed (caller shouldn't reach here)</li>
+     *   <li>1 axis separated → single connector spanning the gap, using the perpendicular overlap</li>
+     *   <li>2 axes separated → L-shape made of two perpendicular connectors meeting at a corner</li>
+     *   <li>3 axes separated → skipped (returns empty); rare and visually confusing</li>
      * </ul>
      */
-    private static BoundingBox buildConnector(BoundingBox a, BoundingBox b, int padding) {
+    private static List<BoundingBox> buildBridge(BoundingBox a, BoundingBox b, int padding) {
         int xGap = axisGap(a.minX(), a.maxX(), b.minX(), b.maxX());
         int yGap = axisGap(a.minY(), a.maxY(), b.minY(), b.maxY());
         int zGap = axisGap(a.minZ(), a.maxZ(), b.minZ(), b.maxZ());
-        int separatedAxes = (xGap > 0 ? 1 : 0) + (yGap > 0 ? 1 : 0) + (zGap > 0 ? 1 : 0);
-        if (separatedAxes == 0) return null;
-        if (separatedAxes >= 2) return null;
+        int axes = (xGap > 0 ? 1 : 0) + (yGap > 0 ? 1 : 0) + (zGap > 0 ? 1 : 0);
 
+        if (axes == 0) return List.of();
+        if (axes >= 3) return List.of();
+
+        if (axes == 1) {
+            return List.of(singleAxisBridge(a, b, padding));
+        }
+        return lBridge(a, b, padding, xGap > 0, yGap > 0, zGap > 0);
+    }
+
+    private static BoundingBox singleAxisBridge(BoundingBox a, BoundingBox b, int padding) {
         int[] x = axisSpan(a.minX(), a.maxX(), b.minX(), b.maxX());
         int[] y = axisSpan(a.minY(), a.maxY(), b.minY(), b.maxY());
         int[] z = axisSpan(a.minZ(), a.maxZ(), b.minZ(), b.maxZ());
-
-        BoundingBox connector = new BoundingBox(x[0], y[0], z[0], x[1], y[1], z[1]);
-        return padding > 0 ? connector.inflatedBy(padding) : connector;
+        BoundingBox bridge = new BoundingBox(x[0], y[0], z[0], x[1], y[1], z[1]);
+        return padding > 0 ? bridge.inflatedBy(padding) : bridge;
     }
 
-    /** True when {@code outer}'s BB fully contains {@code inner}'s BB and the two are not equal. */
+    /**
+     * Builds two perpendicular connectors forming an L between {@code a} and {@code b}.
+     * The corner sits at {@code a}'s edge in the "first" gapped axis and {@code b}'s edge in
+     * the "second" gapped axis — i.e. the bridge leaves {@code a} along one axis, then turns
+     * and enters {@code b} along the other.
+     */
+    private static List<BoundingBox> lBridge(BoundingBox a, BoundingBox b, int padding,
+                                              boolean gapX, boolean gapY, boolean gapZ) {
+        // Determine which two axes are gapped. The third axis must overlap (axes == 2 case).
+        int[] xSpan = axisSpan(a.minX(), a.maxX(), b.minX(), b.maxX());
+        int[] ySpan = axisSpan(a.minY(), a.maxY(), b.minY(), b.maxY());
+        int[] zSpan = axisSpan(a.minZ(), a.maxZ(), b.minZ(), b.maxZ());
+
+        // First segment uses a's range in the second-gapped axis; second segment uses b's
+        // range in the first-gapped axis. Pick axis order so the order is deterministic
+        // (X before Y before Z).
+        BoundingBox seg1, seg2;
+        if (gapX && gapZ) {
+            // First leg along X at a's Z; second leg along Z at b's X.
+            seg1 = new BoundingBox(xSpan[0], ySpan[0], a.minZ(), xSpan[1], ySpan[1], a.maxZ());
+            seg2 = new BoundingBox(b.minX(), ySpan[0], zSpan[0], b.maxX(), ySpan[1], zSpan[1]);
+        } else if (gapX && gapY) {
+            // First leg along X at a's Y; second leg along Y at b's X.
+            seg1 = new BoundingBox(xSpan[0], a.minY(), zSpan[0], xSpan[1], a.maxY(), zSpan[1]);
+            seg2 = new BoundingBox(b.minX(), ySpan[0], zSpan[0], b.maxX(), ySpan[1], zSpan[1]);
+        } else {
+            // gapY && gapZ — first leg along Y at a's Z; second leg along Z at b's Y.
+            seg1 = new BoundingBox(xSpan[0], ySpan[0], a.minZ(), xSpan[1], ySpan[1], a.maxZ());
+            seg2 = new BoundingBox(xSpan[0], b.minY(), zSpan[0], xSpan[1], b.maxY(), zSpan[1]);
+        }
+        if (padding > 0) {
+            seg1 = seg1.inflatedBy(padding);
+            seg2 = seg2.inflatedBy(padding);
+        }
+        return List.of(seg1, seg2);
+    }
+
+    /**
+     * "3-Block-Erweiterung" — see class javadoc. Scans the union per (x,z) column, finds
+     * each contiguous occupied Y-interval, and for any interval thinner than {@code minHeight}
+     * records a cap requirement on top of it. Cap requirements are then merged into rectangles
+     * via greedy strip merging (extend along Z first, then along X while the full Z-strip
+     * matches) and returned appended to the original shapes.
+     */
+    private static List<BoundingBox> ensureMinHeight(List<BoundingBox> shapes, int minHeight) {
+        if (shapes.isEmpty() || minHeight <= 1) return shapes;
+
+        int envMinX = Integer.MAX_VALUE, envMaxX = Integer.MIN_VALUE;
+        int envMinZ = Integer.MAX_VALUE, envMaxZ = Integer.MIN_VALUE;
+        for (BoundingBox s : shapes) {
+            if (s.minX() < envMinX) envMinX = s.minX();
+            if (s.maxX() > envMaxX) envMaxX = s.maxX();
+            if (s.minZ() < envMinZ) envMinZ = s.minZ();
+            if (s.maxZ() > envMaxZ) envMaxZ = s.maxZ();
+        }
+        int width = envMaxX - envMinX + 1;
+        int depth = envMaxZ - envMinZ + 1;
+
+        // Per-column cap requirement: [capMinY, capMaxY]. Sentinel capMinY = Integer.MIN_VALUE.
+        int[] capMinY = new int[width * depth];
+        int[] capMaxY = new int[width * depth];
+        Arrays.fill(capMinY, Integer.MIN_VALUE);
+
+        // Reusable interval buffer: pairs (minY, maxY) for shapes covering one column.
+        int[] ivBuf = new int[shapes.size() * 2];
+
+        for (int xi = 0; xi < width; xi++) {
+            int x = envMinX + xi;
+            for (int zi = 0; zi < depth; zi++) {
+                int z = envMinZ + zi;
+
+                int n = 0;
+                for (BoundingBox s : shapes) {
+                    if (x >= s.minX() && x <= s.maxX() && z >= s.minZ() && z <= s.maxZ()) {
+                        ivBuf[2 * n] = s.minY();
+                        ivBuf[2 * n + 1] = s.maxY();
+                        n++;
+                    }
+                }
+                if (n == 0) continue;
+
+                // Insertion sort by minY (n is small in practice).
+                for (int i = 1; i < n; i++) {
+                    int a = ivBuf[2 * i], b = ivBuf[2 * i + 1];
+                    int j = i - 1;
+                    while (j >= 0 && ivBuf[2 * j] > a) {
+                        ivBuf[2 * (j + 1)] = ivBuf[2 * j];
+                        ivBuf[2 * (j + 1) + 1] = ivBuf[2 * j + 1];
+                        j--;
+                    }
+                    ivBuf[2 * (j + 1)] = a;
+                    ivBuf[2 * (j + 1) + 1] = b;
+                }
+
+                // Walk merged intervals; track the topmost thin one (its top determines the
+                // cap base, its bottom determines how high the cap must reach).
+                int curMin = ivBuf[0], curMax = ivBuf[1];
+                int chosenTopY = Integer.MIN_VALUE;
+                int chosenCapTop = Integer.MIN_VALUE;
+                for (int i = 1; i < n; i++) {
+                    int a = ivBuf[2 * i], b = ivBuf[2 * i + 1];
+                    if (a <= curMax + 1) {
+                        if (b > curMax) curMax = b;
+                    } else {
+                        if (curMax - curMin + 1 < minHeight && curMax > chosenTopY) {
+                            chosenTopY = curMax;
+                            chosenCapTop = curMin + minHeight - 1;
+                        }
+                        curMin = a;
+                        curMax = b;
+                    }
+                }
+                if (curMax - curMin + 1 < minHeight && curMax > chosenTopY) {
+                    chosenTopY = curMax;
+                    chosenCapTop = curMin + minHeight - 1;
+                }
+
+                if (chosenTopY != Integer.MIN_VALUE) {
+                    int idx = xi * depth + zi;
+                    capMinY[idx] = chosenTopY + 1;
+                    capMaxY[idx] = chosenCapTop;
+                }
+            }
+        }
+
+        // Greedy strip merge: collapse equal-cap columns into rectangles.
+        List<BoundingBox> caps = new ArrayList<>();
+        boolean[] used = new boolean[width * depth];
+        for (int xi = 0; xi < width; xi++) {
+            for (int zi = 0; zi < depth; zi++) {
+                int idx = xi * depth + zi;
+                if (used[idx] || capMinY[idx] == Integer.MIN_VALUE) continue;
+                int cMin = capMinY[idx], cMax = capMaxY[idx];
+
+                int z1 = zi;
+                while (z1 + 1 < depth) {
+                    int nIdx = xi * depth + (z1 + 1);
+                    if (used[nIdx] || capMinY[nIdx] != cMin || capMaxY[nIdx] != cMax) break;
+                    z1++;
+                }
+                int x1 = xi;
+                while (x1 + 1 < width) {
+                    boolean ok = true;
+                    for (int z = zi; z <= z1; z++) {
+                        int nIdx = (x1 + 1) * depth + z;
+                        if (used[nIdx] || capMinY[nIdx] != cMin || capMaxY[nIdx] != cMax) {
+                            ok = false;
+                            break;
+                        }
+                    }
+                    if (!ok) break;
+                    x1++;
+                }
+                for (int x = xi; x <= x1; x++) {
+                    for (int z = zi; z <= z1; z++) used[x * depth + z] = true;
+                }
+                caps.add(new BoundingBox(envMinX + xi, cMin, envMinZ + zi,
+                                          envMinX + x1, cMax, envMinZ + z1));
+            }
+        }
+
+        if (caps.isEmpty()) return shapes;
+        List<BoundingBox> result = new ArrayList<>(shapes.size() + caps.size());
+        result.addAll(shapes);
+        result.addAll(caps);
+        return result;
+    }
+
+    private static BoundingBox envelopeOf(List<BoundingBox> shapes) {
+        int minX = Integer.MAX_VALUE, minY = Integer.MAX_VALUE, minZ = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE, maxY = Integer.MIN_VALUE, maxZ = Integer.MIN_VALUE;
+        for (BoundingBox s : shapes) {
+            if (s.minX() < minX) minX = s.minX();
+            if (s.minY() < minY) minY = s.minY();
+            if (s.minZ() < minZ) minZ = s.minZ();
+            if (s.maxX() > maxX) maxX = s.maxX();
+            if (s.maxY() > maxY) maxY = s.maxY();
+            if (s.maxZ() > maxZ) maxZ = s.maxZ();
+        }
+        return new BoundingBox(minX, minY, minZ, maxX, maxY, maxZ);
+    }
+
+    private static boolean intersects(BoundingBox a, BoundingBox b) {
+        return a.maxX() >= b.minX() && a.minX() <= b.maxX()
+            && a.maxY() >= b.minY() && a.minY() <= b.maxY()
+            && a.maxZ() >= b.minZ() && a.minZ() <= b.maxZ();
+    }
+
     private static boolean strictlyContains(BoundingBox outer, BoundingBox inner) {
         boolean contains =
                 outer.minX() <= inner.minX() && outer.maxX() >= inner.maxX() &&
@@ -225,18 +493,5 @@ public final class ClusterBuilder {
         if (aMax < bMin) return bMin - aMax;
         if (bMax < aMin) return aMin - bMax;
         return 0;
-    }
-
-    private static int find(int[] parent, int i) {
-        while (parent[i] != i) {
-            parent[i] = parent[parent[i]];
-            i = parent[i];
-        }
-        return i;
-    }
-
-    private static void union(int[] parent, int a, int b) {
-        int ra = find(parent, a), rb = find(parent, b);
-        if (ra != rb) parent[ra] = rb;
     }
 }

--- a/src/main/java/net/bananemdnsa/historystages/structure/ClusterDebugRenderer.java
+++ b/src/main/java/net/bananemdnsa/historystages/structure/ClusterDebugRenderer.java
@@ -84,14 +84,14 @@ public final class ClusterDebugRenderer {
             if (clusterDistSq <= PIECE_DRAW_DISTANCE_SQ) {
                 for (BoundingBox piece : cluster.pieceBoxes()) {
                     if (distSqToBox(piece, px, py, pz) > PIECE_DRAW_DISTANCE_SQ) continue;
-                    drawBoxEdges(level, player, piece, PIECE_PARTICLE);
+                    drawBoxEdges(level, player, piece, PIECE_PARTICLE, cluster.pieceBoxes());
                 }
             }
 
             ParticleOptions shapeParticle = active.contains(cluster) ? CLUSTER_ACTIVE : CLUSTER_NEUTRAL;
             for (BoundingBox shape : cluster.lockShapes()) {
                 if (distSqToBox(shape, px, py, pz) > MAX_SHAPE_DISTANCE_SQ) continue;
-                drawBoxEdges(level, player, shape, shapeParticle);
+                drawBoxEdges(level, player, shape, shapeParticle, cluster.lockShapes());
             }
         }
     }
@@ -110,28 +110,29 @@ public final class ClusterDebugRenderer {
         return 0.0;
     }
 
-    private static void drawBoxEdges(ServerLevel level, ServerPlayer player, BoundingBox bb, ParticleOptions particle) {
+    private static void drawBoxEdges(ServerLevel level, ServerPlayer player, BoundingBox bb,
+                                      ParticleOptions particle, List<BoundingBox> occluders) {
         double x0 = bb.minX(), y0 = bb.minY(), z0 = bb.minZ();
         double x1 = bb.maxX() + 1.0, y1 = bb.maxY() + 1.0, z1 = bb.maxZ() + 1.0;
 
-        drawLine(level, player, x0, y0, z0, x1, y0, z0, particle);
-        drawLine(level, player, x0, y0, z1, x1, y0, z1, particle);
-        drawLine(level, player, x0, y0, z0, x0, y0, z1, particle);
-        drawLine(level, player, x1, y0, z0, x1, y0, z1, particle);
-        drawLine(level, player, x0, y1, z0, x1, y1, z0, particle);
-        drawLine(level, player, x0, y1, z1, x1, y1, z1, particle);
-        drawLine(level, player, x0, y1, z0, x0, y1, z1, particle);
-        drawLine(level, player, x1, y1, z0, x1, y1, z1, particle);
-        drawLine(level, player, x0, y0, z0, x0, y1, z0, particle);
-        drawLine(level, player, x1, y0, z0, x1, y1, z0, particle);
-        drawLine(level, player, x0, y0, z1, x0, y1, z1, particle);
-        drawLine(level, player, x1, y0, z1, x1, y1, z1, particle);
+        drawLine(level, player, x0, y0, z0, x1, y0, z0, particle, bb, occluders);
+        drawLine(level, player, x0, y0, z1, x1, y0, z1, particle, bb, occluders);
+        drawLine(level, player, x0, y0, z0, x0, y0, z1, particle, bb, occluders);
+        drawLine(level, player, x1, y0, z0, x1, y0, z1, particle, bb, occluders);
+        drawLine(level, player, x0, y1, z0, x1, y1, z0, particle, bb, occluders);
+        drawLine(level, player, x0, y1, z1, x1, y1, z1, particle, bb, occluders);
+        drawLine(level, player, x0, y1, z0, x0, y1, z1, particle, bb, occluders);
+        drawLine(level, player, x1, y1, z0, x1, y1, z1, particle, bb, occluders);
+        drawLine(level, player, x0, y0, z0, x0, y1, z0, particle, bb, occluders);
+        drawLine(level, player, x1, y0, z0, x1, y1, z0, particle, bb, occluders);
+        drawLine(level, player, x0, y0, z1, x0, y1, z1, particle, bb, occluders);
+        drawLine(level, player, x1, y0, z1, x1, y1, z1, particle, bb, occluders);
     }
 
     private static void drawLine(ServerLevel level, ServerPlayer player,
                                  double x0, double y0, double z0,
                                  double x1, double y1, double z1,
-                                 ParticleOptions particle) {
+                                 ParticleOptions particle, BoundingBox owner, List<BoundingBox> occluders) {
         double dx = x1 - x0, dy = y1 - y0, dz = z1 - z0;
         double length = Math.sqrt(dx * dx + dy * dy + dz * dz);
         if (length <= 0) return;
@@ -141,7 +142,25 @@ public final class ClusterDebugRenderer {
             double x = x0 + dx * t;
             double y = y0 + dy * t;
             double z = z0 + dz * t;
+            if (isHidden(x, y, z, owner, occluders)) continue;
             level.sendParticles(player, particle, false, x, y, z, 1, 0, 0, 0, 0);
         }
+    }
+
+    /**
+     * True when the point lies strictly inside another box in the same cluster — the edge is
+     * an interior seam, not part of the outer silhouette. Strict inequality keeps points on
+     * shared faces visible (those ARE the silhouette where two boxes meet flush).
+     */
+    private static boolean isHidden(double x, double y, double z, BoundingBox owner, List<BoundingBox> occluders) {
+        for (BoundingBox other : occluders) {
+            if (other == owner) continue;
+            if (x > other.minX() && x < other.maxX() + 1.0
+                    && y > other.minY() && y < other.maxY() + 1.0
+                    && z > other.minZ() && z < other.maxZ() + 1.0) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/net/bananemdnsa/historystages/structure/ClusterDebugRenderer.java
+++ b/src/main/java/net/bananemdnsa/historystages/structure/ClusterDebugRenderer.java
@@ -1,0 +1,147 @@
+package net.bananemdnsa.historystages.structure;
+
+import net.minecraft.core.particles.DustParticleOptions;
+import net.minecraft.core.particles.ParticleOptions;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import org.joml.Vector3f;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Temporary debug visualization for {@link StructureCluster} bounds. Opt-in per player via
+ * {@code /history debug viz}. Renders piece outlines (white) and lock-shape outlines
+ * (orange / red) using particles sent only to the opted-in player.
+ *
+ * <p>Throughput is the main performance concern: each particle is one network packet.
+ * To keep cost bounded we apply three filters before drawing:
+ * <ul>
+ *   <li>broad-phase distance test on the cluster envelope ({@link #MAX_SHAPE_DISTANCE_SQ}),</li>
+ *   <li>fine-phase distance test on each individual shape,</li>
+ *   <li>piece outlines (the densest layer) are drawn only at close range
+ *       ({@link #PIECE_DRAW_DISTANCE_SQ}).</li>
+ * </ul>
+ */
+public final class ClusterDebugRenderer {
+
+    private static final Set<UUID> ENABLED = new HashSet<>();
+
+    /** Render every N ticks. Lower = smoother but more network traffic. */
+    private static final int RENDER_INTERVAL = 20;
+    /** Distance between particles along a BB edge, in blocks. Larger = fewer particles. */
+    private static final double PARTICLE_STEP = 2.0;
+    /** Beyond this squared distance from the player, a shape is skipped entirely. */
+    private static final double MAX_SHAPE_DISTANCE_SQ = 48 * 48;
+    /** Piece outlines (white, densest layer) are only drawn within this squared distance. */
+    private static final double PIECE_DRAW_DISTANCE_SQ = 24 * 24;
+
+    private static final ParticleOptions PIECE_PARTICLE =
+            new DustParticleOptions(new Vector3f(1.0f, 1.0f, 1.0f), 1.0f);
+    private static final ParticleOptions CLUSTER_NEUTRAL =
+            new DustParticleOptions(new Vector3f(1.0f, 0.6f, 0.1f), 1.2f);
+    private static final ParticleOptions CLUSTER_ACTIVE =
+            new DustParticleOptions(new Vector3f(1.0f, 0.1f, 0.1f), 1.4f);
+
+    private ClusterDebugRenderer() {}
+
+    public static boolean toggle(UUID uuid) {
+        if (ENABLED.contains(uuid)) {
+            ENABLED.remove(uuid);
+            return false;
+        }
+        ENABLED.add(uuid);
+        return true;
+    }
+
+    public static void disable(UUID uuid) {
+        ENABLED.remove(uuid);
+    }
+
+    public static boolean isEnabled(UUID uuid) {
+        return ENABLED.contains(uuid);
+    }
+
+    public static void tick(ServerPlayer player, List<StructureCluster> nearby, List<StructureCluster> activeLocked) {
+        if (!ENABLED.contains(player.getUUID())) return;
+        if (player.tickCount % RENDER_INTERVAL != 0) return;
+        if (nearby == null || nearby.isEmpty()) return;
+
+        ServerLevel level = player.serverLevel();
+        Set<StructureCluster> active = activeLocked == null ? Set.of() : new HashSet<>(activeLocked);
+
+        double px = player.getX(), py = player.getY(), pz = player.getZ();
+
+        for (StructureCluster cluster : nearby) {
+            double clusterDistSq = distSqToBox(cluster.bounds(), px, py, pz);
+            if (clusterDistSq > MAX_SHAPE_DISTANCE_SQ) continue;
+
+            // Piece outlines only at close range — they're the densest and most redundant
+            // with the lock-shape outlines (which already contain the inflated pieces).
+            if (clusterDistSq <= PIECE_DRAW_DISTANCE_SQ) {
+                for (BoundingBox piece : cluster.pieceBoxes()) {
+                    if (distSqToBox(piece, px, py, pz) > PIECE_DRAW_DISTANCE_SQ) continue;
+                    drawBoxEdges(level, player, piece, PIECE_PARTICLE);
+                }
+            }
+
+            ParticleOptions shapeParticle = active.contains(cluster) ? CLUSTER_ACTIVE : CLUSTER_NEUTRAL;
+            for (BoundingBox shape : cluster.lockShapes()) {
+                if (distSqToBox(shape, px, py, pz) > MAX_SHAPE_DISTANCE_SQ) continue;
+                drawBoxEdges(level, player, shape, shapeParticle);
+            }
+        }
+    }
+
+    /** Squared min distance from a point to a BlockPos-based bounding box. */
+    private static double distSqToBox(BoundingBox bb, double px, double py, double pz) {
+        double dx = clampDelta(px, bb.minX(), bb.maxX() + 1.0);
+        double dy = clampDelta(py, bb.minY(), bb.maxY() + 1.0);
+        double dz = clampDelta(pz, bb.minZ(), bb.maxZ() + 1.0);
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    private static double clampDelta(double p, double min, double max) {
+        if (p < min) return min - p;
+        if (p > max) return p - max;
+        return 0.0;
+    }
+
+    private static void drawBoxEdges(ServerLevel level, ServerPlayer player, BoundingBox bb, ParticleOptions particle) {
+        double x0 = bb.minX(), y0 = bb.minY(), z0 = bb.minZ();
+        double x1 = bb.maxX() + 1.0, y1 = bb.maxY() + 1.0, z1 = bb.maxZ() + 1.0;
+
+        drawLine(level, player, x0, y0, z0, x1, y0, z0, particle);
+        drawLine(level, player, x0, y0, z1, x1, y0, z1, particle);
+        drawLine(level, player, x0, y0, z0, x0, y0, z1, particle);
+        drawLine(level, player, x1, y0, z0, x1, y0, z1, particle);
+        drawLine(level, player, x0, y1, z0, x1, y1, z0, particle);
+        drawLine(level, player, x0, y1, z1, x1, y1, z1, particle);
+        drawLine(level, player, x0, y1, z0, x0, y1, z1, particle);
+        drawLine(level, player, x1, y1, z0, x1, y1, z1, particle);
+        drawLine(level, player, x0, y0, z0, x0, y1, z0, particle);
+        drawLine(level, player, x1, y0, z0, x1, y1, z0, particle);
+        drawLine(level, player, x0, y0, z1, x0, y1, z1, particle);
+        drawLine(level, player, x1, y0, z1, x1, y1, z1, particle);
+    }
+
+    private static void drawLine(ServerLevel level, ServerPlayer player,
+                                 double x0, double y0, double z0,
+                                 double x1, double y1, double z1,
+                                 ParticleOptions particle) {
+        double dx = x1 - x0, dy = y1 - y0, dz = z1 - z0;
+        double length = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        if (length <= 0) return;
+        int steps = Math.max(1, (int) Math.ceil(length / PARTICLE_STEP));
+        for (int i = 0; i <= steps; i++) {
+            double t = (double) i / steps;
+            double x = x0 + dx * t;
+            double y = y0 + dy * t;
+            double z = z0 + dz * t;
+            level.sendParticles(player, particle, false, x, y, z, 1, 0, 0, 0, 0);
+        }
+    }
+}

--- a/src/main/java/net/bananemdnsa/historystages/structure/StructureCluster.java
+++ b/src/main/java/net/bananemdnsa/historystages/structure/StructureCluster.java
@@ -1,0 +1,32 @@
+package net.bananemdnsa.historystages.structure;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.minecraft.world.level.levelgen.structure.Structure;
+
+import java.util.List;
+
+/**
+ * A connected lock zone for one structure. The actual lock area is the union of
+ * {@code lockShapes} — inflated piece bounding boxes plus connector boxes that
+ * bridge nearby pieces. The {@code bounds} field is the axis-aligned envelope of
+ * those shapes and is used as a cheap broad-phase test before iterating shapes.
+ *
+ * <p>{@code pieceBoxes} retains the original, un-inflated piece BBs purely for
+ * debug rendering (white outlines of the actual structure geometry).
+ */
+public record StructureCluster(
+        BoundingBox bounds,
+        Holder.Reference<Structure> structure,
+        List<BoundingBox> pieceBoxes,
+        List<BoundingBox> lockShapes
+) {
+    public boolean contains(BlockPos pos) {
+        if (!bounds.isInside(pos)) return false;
+        for (BoundingBox shape : lockShapes) {
+            if (shape.isInside(pos)) return true;
+        }
+        return false;
+    }
+}

--- a/src/main/resources/assets/historystages/lang/de_de.json
+++ b/src/main/resources/assets/historystages/lang/de_de.json
@@ -194,7 +194,6 @@
   "editor.historystages.config.structureDamageInterval": "Schadensintervall (Ticks)",
   "editor.historystages.config.structureBlockRightClick": "Rechtsklick blockieren",
   "editor.historystages.config.structureBlockLeftClick": "Linksklick blockieren",
-  "editor.historystages.config.structureWallMode": "Wand-Modus (Rückstoß)",
   "editor.historystages.config.structureBlockProjectiles": "Projektile blockieren",
 
   "editor.historystages.config.lock_messages": "Lock-Nachrichten",

--- a/src/main/resources/assets/historystages/lang/de_de.json
+++ b/src/main/resources/assets/historystages/lang/de_de.json
@@ -192,6 +192,8 @@
   "editor.historystages.config.structureDamageEnabled": "Schaden in Strukturen",
   "editor.historystages.config.structureDamageAmount": "Schadensmenge",
   "editor.historystages.config.structureDamageInterval": "Schadensintervall (Ticks)",
+  "editor.historystages.config.structureBlockRightClick": "Rechtsklick blockieren",
+  "editor.historystages.config.structureBlockLeftClick": "Linksklick blockieren",
 
   "editor.historystages.config.lock_messages": "Lock-Nachrichten",
   "editor.historystages.config.msgDimensionUnknown": "Dimension unbekannt",

--- a/src/main/resources/assets/historystages/lang/de_de.json
+++ b/src/main/resources/assets/historystages/lang/de_de.json
@@ -201,6 +201,12 @@
   "editor.historystages.config.msgEntityItemLocked": "Auslage gesperrt",
   "editor.historystages.config.msgEnchantmentLocked": "Verzauberung gesperrt",
 
+  "editor.historystages.config.structure_visuals": "Struktursperre-Visuals",
+  "editor.historystages.config.structureBorderEnabled": "Force-Field-Rand anzeigen",
+  "editor.historystages.config.structureBorderDistance": "Sichtbarkeitsdistanz Rand",
+  "editor.historystages.config.structureLockOverlayEnabled": "Roter Bildschirm-Overlay",
+  "editor.historystages.config.structureLockOverlayOpacity": "Overlay-Deckkraft",
+
   "editor.historystages.config.dependencies": "Abh\u00e4ngigkeiten",
   "editor.historystages.config.showDependenciesOnScroll": "Abh\u00e4ngigkeiten auf Rolle zeigen",
   "editor.historystages.config.hideFulfilledDependencies": "Erf\u00fcllte ausblenden",

--- a/src/main/resources/assets/historystages/lang/de_de.json
+++ b/src/main/resources/assets/historystages/lang/de_de.json
@@ -194,6 +194,8 @@
   "editor.historystages.config.structureDamageInterval": "Schadensintervall (Ticks)",
   "editor.historystages.config.structureBlockRightClick": "Rechtsklick blockieren",
   "editor.historystages.config.structureBlockLeftClick": "Linksklick blockieren",
+  "editor.historystages.config.structureWallMode": "Wand-Modus (Rückstoß)",
+  "editor.historystages.config.structureBlockProjectiles": "Projektile blockieren",
 
   "editor.historystages.config.lock_messages": "Lock-Nachrichten",
   "editor.historystages.config.msgDimensionUnknown": "Dimension unbekannt",

--- a/src/main/resources/assets/historystages/lang/en_us.json
+++ b/src/main/resources/assets/historystages/lang/en_us.json
@@ -194,7 +194,6 @@
   "editor.historystages.config.structureDamageInterval": "Damage Interval (ticks)",
   "editor.historystages.config.structureBlockRightClick": "Block Right-Click",
   "editor.historystages.config.structureBlockLeftClick": "Block Left-Click",
-  "editor.historystages.config.structureWallMode": "Wall Mode (bounce-back)",
   "editor.historystages.config.structureBlockProjectiles": "Block Projectiles",
 
   "editor.historystages.config.lock_messages": "Lock Messages",

--- a/src/main/resources/assets/historystages/lang/en_us.json
+++ b/src/main/resources/assets/historystages/lang/en_us.json
@@ -201,6 +201,12 @@
   "editor.historystages.config.msgEntityItemLocked": "Entity Item Locked",
   "editor.historystages.config.msgEnchantmentLocked": "Enchantment Locked",
 
+  "editor.historystages.config.structure_visuals": "Structure Lock Visuals",
+  "editor.historystages.config.structureBorderEnabled": "Show Force-Field Border",
+  "editor.historystages.config.structureBorderDistance": "Border Reveal Distance",
+  "editor.historystages.config.structureLockOverlayEnabled": "Red Screen Overlay",
+  "editor.historystages.config.structureLockOverlayOpacity": "Overlay Opacity",
+
   "editor.historystages.config.dependencies": "Dependencies",
   "editor.historystages.config.showDependenciesOnScroll": "Show Dependencies on Scroll",
   "editor.historystages.config.hideFulfilledDependencies": "Hide Fulfilled Dependencies",

--- a/src/main/resources/assets/historystages/lang/en_us.json
+++ b/src/main/resources/assets/historystages/lang/en_us.json
@@ -194,6 +194,8 @@
   "editor.historystages.config.structureDamageInterval": "Damage Interval (ticks)",
   "editor.historystages.config.structureBlockRightClick": "Block Right-Click",
   "editor.historystages.config.structureBlockLeftClick": "Block Left-Click",
+  "editor.historystages.config.structureWallMode": "Wall Mode (bounce-back)",
+  "editor.historystages.config.structureBlockProjectiles": "Block Projectiles",
 
   "editor.historystages.config.lock_messages": "Lock Messages",
   "editor.historystages.config.msgDimensionUnknown": "Dimension Unknown",

--- a/src/main/resources/assets/historystages/lang/en_us.json
+++ b/src/main/resources/assets/historystages/lang/en_us.json
@@ -192,6 +192,8 @@
   "editor.historystages.config.structureDamageEnabled": "Damage in Structures",
   "editor.historystages.config.structureDamageAmount": "Damage Amount",
   "editor.historystages.config.structureDamageInterval": "Damage Interval (ticks)",
+  "editor.historystages.config.structureBlockRightClick": "Block Right-Click",
+  "editor.historystages.config.structureBlockLeftClick": "Block Left-Click",
 
   "editor.historystages.config.lock_messages": "Lock Messages",
   "editor.historystages.config.msgDimensionUnknown": "Dimension Unknown",


### PR DESCRIPTION
## Related Issue
Refs #62 — implements the structure-lock tightening and visual warning
requested.

## Summary (required)
Reworks the structure lock so the zone hugs the actual structure geometry
instead of the chunk-sized envelope, and adds visual feedback (red force-
field border, red screen overlay inside) so players see the lock before
walking into it.

## What changed
- New seeded cluster builder: per-piece overlap-merge, 6-block bridge
  search (single-axis + L-shape), per-column 5-block height cap, +2-block
  safety padding always added on top of `structureLockPadding`.
- Server pushes full `lockShapes` list to client (not the envelope).
  Renderer subdivides each face into 1-block cells with silhouette
  culling and coincident-face dedup; force-field tinted saturated red,
  depth-tested.
- New red full-screen overlay while inside a locked zone.
- Right-click (block / item / entity) and left-click (block-break /
  attack) cancelled when player OR target is inside a zone. Anti-cheese
  closes the "mine through the wall" + bucket-from-outside + projectile
  + explosion vectors.
- Cancel chain uses `setUseBlock/Item(FALSE) + setCancellationResult(FAIL)
  + containerMenu.broadcastFullState()` so the placed/used item isn't
  lost from inventory.
- Per-tick fast containment recheck — lock state reacts in 1 tick instead
  of up to `structureCheckInterval`.
- `PlayerLoggedOutEvent` cleans the per-UUID state map.
- All new settings (border + overlay + interaction toggles + projectile
  toggle) wired through the in-game editor with DE/EN labels.

## Why
Issue #62 — underground structures locked the whole chunk, players above
died unknowingly. Two requested fixes: tighten the geometry, add a visual
warning. Plus closes the obvious cheese vectors (mine through, shoot
over, TNT from outside).

## Type of Change (required)
- [x] Bug fix
- [x] New feature
- [x] Refactoring / cleanup
- [x] Configuration / stage JSON change

## Breaking Changes (required)
- `structureLockPadding` default lowered from 1 to 0; `SAFETY_PADDING = 2`
  is now always added on top, so effective padding is `(lockPadding + 2)`.
  Custom values get +2 blocks effective; comment updated.
- Lock zone shape changed across the board (piece geometry + bridges
  instead of vanilla start-BB). Existing stage JSON entries unchanged.
- New client + common configs added, all sensible defaults, no migration.

## Testing (required)
Self-tested by author; review-side testing welcome.

## Compatibility Check
- [x] Existing stage JSON files still load without errors
- [x] Existing config keys still work
- [x] No client-only code runs on the dedicated server side
- [x] No server-only code runs on the client side
- [x] Loader-specific code properly guarded

## Checklist (required)
- [x] `gradlew build` passes locally
- [x] Changes follow existing code style
- [x] Public APIs / commands / events documented in code
- [ ] Version number / changelog updated (if release-bound)